### PR TITLE
feat(extsload): expose generic storage getter

### DIFF
--- a/src/Blue.sol
+++ b/src/Blue.sol
@@ -306,7 +306,7 @@ contract Blue {
     function extsload(bytes32[] calldata slots) external view returns (bytes32[] memory res) {
         uint256 nSlots = slots.length;
 
-        res = new bytes32[]( nSlots);
+        res = new bytes32[](nSlots);
 
         for (uint256 i; i < nSlots;) {
             bytes32 slot = slots[i++];

--- a/test/forge/Blue.t.sol
+++ b/test/forge/Blue.t.sol
@@ -686,33 +686,20 @@ contract BlueTest is Test {
         vm.stopPrank();
     }
 
-    function testExtSLoad(uint256 amount, address onBehalf) public {
-        vm.assume(onBehalf != address(blue));
-        amount = bound(amount, 1, 2 ** 64);
+    function testExtsLoad(uint256 slot, bytes32 value0) public {
+        bytes32[] memory slots = new bytes32[](2);
+        slots[0] = bytes32(slot);
+        slots[1] = bytes32(slot / 2);
 
-        borrowableAsset.setBalance(address(this), amount);
-        blue.supply(market, amount, onBehalf);
+        bytes32 value1 = keccak256(abi.encode(value0));
+        vm.store(address(blue), slots[0], value0);
+        vm.store(address(blue), slots[1], value1);
 
-        bytes32[] memory supplyShareSlot = new bytes32[](1);
-        bytes32[] memory totalSupplySlot = new bytes32[](1);
-        bytes32[] memory totalSupplyShareSlot = new bytes32[](1);
+        bytes32[] memory values = blue.extsload(slots);
 
-        supplyShareSlot[0] = keccak256(abi.encode(onBehalf, keccak256(abi.encode(id, 2))));
-        totalSupplySlot[0] = keccak256(abi.encode(id, 5));
-        totalSupplyShareSlot[0] = keccak256(abi.encode(id, 6));
-
-        bytes32[] memory supplyShare = blue.extsload(supplyShareSlot);
-        bytes32[] memory totalSupply = blue.extsload(totalSupplySlot);
-        bytes32[] memory totalSupplyShare = blue.extsload(totalSupplyShareSlot);
-
-        assertEq(supplyShare.length, 1, "supplyShare.length");
-        assertEq(uint256(supplyShare[0]), 1e18, "supplyShare");
-
-        assertEq(totalSupply.length, 1, "totalSupply.length");
-        assertEq(uint256(totalSupply[0]), amount, "totalSupply");
-
-        assertEq(totalSupplyShare.length, 1, "totalSupplyShare.length");
-        assertEq(uint256(totalSupplyShare[0]), 1e18, "totalSupplyShare");
+        assertEq(values.length, 2, "values.length");
+        assertEq(values[0], slot > 0 ? value0 : value1, "value0");
+        assertEq(values[1], value1, "value1");
     }
 }
 


### PR DESCRIPTION
This solution can supplant #138 by just exposing a generic storage getter named `extsload`.

2 design choices were made:
1. The getter expects an array of slots instead of a single slot, because it is expected that integrators need multiple, non-contiguous storage values at once
2. There is no contiguous storage getter because for now, we don't have storage values larger than 32 bytes

If this change is accepted, I believe we should build a simple library helping integrators access the storage value they want, without thinking about the storage slots:

```solidity
library BlueStorageSlots {
  function totalSupply(Id id) internal view returns (bytes32) {
    return keccak256(abi.encode(id, 5));
  }
}
```

Note that if we'd like to provide easy integrations, we could also provide a library for calculating accrued interests:

```solidity
library BlueLib {
  function accruedInterests(IBlue blue, Id id) internal view returns (uint256 interests, uint256 feeShares) {
    // Prepare storage slot array
    // Call extsload
    // Mimick interests calculation
  }
}
```

But then the only advantage of doing so to have a simpler Blue contract (we don't have to separate calculation and storage update, like it's done in #138) but we force integrators to have duplicated code (interests calculation). I'm not sure this trade-off is cool for integrators...