### PR TITLE
refactor(market): oop-like using

### DIFF
--- a/src/Blue.sol
+++ b/src/Blue.sol
@@ -14,7 +14,6 @@ uint256 constant ALPHA = 0.5e18;
 
 contract Blue {
     using MathLib for uint256;
-    using MarketLib for Market;
     using SafeTransferLib for IERC20;
 
     // Storage.

--- a/src/libraries/MarketLib.sol
+++ b/src/libraries/MarketLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.19;
 
 import {IIrm} from "src/interfaces/IIrm.sol";
 import {IERC20} from "src/interfaces/IERC20.sol";
@@ -29,3 +29,5 @@ library MarketLib {
         return Id.wrap(keccak256(abi.encode(market)));
     }
 }
+
+using MarketLib for Market global;

--- a/src/mocks/IrmMock.sol
+++ b/src/mocks/IrmMock.sol
@@ -10,7 +10,6 @@ import {Blue} from "src/Blue.sol";
 
 contract IrmMock is IIrm {
     using MathLib for uint256;
-    using MarketLib for Market;
 
     Blue public immutable blue;
 

--- a/test/forge/Blue.t.sol
+++ b/test/forge/Blue.t.sol
@@ -10,7 +10,6 @@ import {OracleMock as Oracle} from "src/mocks/OracleMock.sol";
 import {IrmMock as Irm} from "src/mocks/IrmMock.sol";
 
 contract BlueTest is Test {
-    using MarketLib for Market;
     using MathLib for uint256;
 
     address private constant BORROWER = address(1234);


### PR DESCRIPTION
Because I love OOP.

Obviously, it's a suggestion. The biggest downside is that it's limited to Solidity 0.8.19 and later. I don't think it's a big deal, but it needs to be highlighted.