### PR TITLE
Feat/repay withdraw all return values

### DIFF
--- a/test/forge/Blue.t.sol
+++ b/test/forge/Blue.t.sol
@@ -378,17 +378,18 @@ contract BlueTest is
         );
     }
 
-    function testWithdrawAll(uint256 amountLent, uint256 amountBorrowed) public {
+    function testWithdrawAll(uint256 amountLent, uint256 amountBorrowed, address receiver) public {
+        vm.assume(receiver != address(blue));
         amountLent = bound(amountLent, 1, 2 ** 64);
         amountBorrowed = bound(amountBorrowed, 1, 2 ** 64);
         vm.assume(amountLent >= amountBorrowed);
 
         borrowableAsset.setBalance(address(this), amountLent);
-        blue.supply(market, amountLent, address(this));
-        blue.withdraw(market, type(uint256).max, address(this));
+        blue.supply(market, amountLent, address(this), hex"");
+        blue.withdraw(market, type(uint256).max, address(this), receiver);
 
         assertEq(blue.supplyShare(id, address(this)), 0, "supply share");
-        assertEq(borrowableAsset.balanceOf(address(this)), amountLent, "this balance");
+        assertEq(borrowableAsset.balanceOf(receiver), amountLent, "receiver balance");
         assertEq(borrowableAsset.balanceOf(address(blue)), 0, "blue balance");
     }
 
@@ -481,15 +482,15 @@ contract BlueTest is
         amountBorrowed = bound(amountBorrowed, 1, amountLent);
 
         borrowableAsset.setBalance(address(this), amountLent);
-        blue.supply(market, amountLent, address(this));
+        blue.supply(market, amountLent, address(this), hex"");
 
         vm.startPrank(BORROWER);
-        blue.borrow(market, amountBorrowed, BORROWER);
-        blue.repay(market, type(uint256).max, BORROWER);
+        blue.borrow(market, amountBorrowed, BORROWER, BORROWER);
+        blue.repay(market, type(uint256).max, BORROWER, hex"");
         vm.stopPrank();
 
         assertEq(blue.borrowShare(id, BORROWER), 0, "borrow share");
-        assertEq(borrowableAsset.balanceOf(BORROWER), 0, "BORROWER balance");
+        assertEq(borrowableAsset.balanceOf(BORROWER), 0, "receiver balance");
         assertEq(borrowableAsset.balanceOf(address(blue)), amountLent, "blue balance");
     }
 
@@ -526,15 +527,16 @@ contract BlueTest is
         assertEq(collateralAsset.balanceOf(address(blue)), amountDeposited - amountWithdrawn, "blue balance");
     }
 
-    function testWithdrawCollateralAll(uint256 amountDeposited) public {
+    function testWithdrawCollateralAll(uint256 amountDeposited, address receiver) public {
+        vm.assume(receiver != address(blue));
         amountDeposited = bound(amountDeposited, 1, 2 ** 64);
 
         collateralAsset.setBalance(address(this), amountDeposited);
-        blue.supplyCollateral(market, amountDeposited, address(this));
-        blue.withdrawCollateral(market, type(uint256).max, address(this));
+        blue.supplyCollateral(market, amountDeposited, address(this), hex"");
+        blue.withdrawCollateral(market, type(uint256).max, address(this), receiver);
 
         assertEq(blue.collateral(id, address(this)), 0, "this collateral");
-        assertEq(collateralAsset.balanceOf(address(this)), amountDeposited, "this balance");
+        assertEq(collateralAsset.balanceOf(receiver), amountDeposited, "receiver balance");
         assertEq(collateralAsset.balanceOf(address(blue)), 0, "blue balance");
     }
 


### PR DESCRIPTION
As an integrator, it avoids having to do:

```solidity
  uint256 balanceBefore = market.borrowableAsset.balanceOf(address(this));
  _BLUE.withdraw(market, amount, msg.sender);
  uint256 withdrawn = market.borrowableAsset.balanceOf(address(this)) - balanceBefore;
```

And instead do:

```solidity
  uint256 withdrawn = _BLUE.withdraw(market, amount, msg.sender);
```

Gas diff: https://github.com/morpho-labs/blue/pull/185