### PR TITLE
feat(callbacks): return data in callbacks

### DIFF
--- a/src/Blue.sol
+++ b/src/Blue.sol
@@ -308,10 +308,10 @@ contract Blue {
 
     // Flash Loans.
 
-    function flashLoan(address token, uint256 amount, bytes calldata data) external {
+    function flashLoan(address token, uint256 amount, bytes calldata data) external returns (bytes memory returnData) {
         IERC20(token).safeTransfer(msg.sender, amount);
 
-        IBlueFlashLoanCallback(msg.sender).onBlueFlashLoan(token, amount, data);
+        returnData = IBlueFlashLoanCallback(msg.sender).onBlueFlashLoan(token, amount, data);
 
         IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
     }

--- a/src/interfaces/IBlueCallbacks.sol
+++ b/src/interfaces/IBlueCallbacks.sol
@@ -18,5 +18,5 @@ interface IBlueSupplyCollateralCallback {
 }
 
 interface IBlueFlashLoanCallback {
-    function onBlueFlashLoan(address token, uint256 amount, bytes calldata data) external;
+    function onBlueFlashLoan(address token, uint256 amount, bytes calldata data) external returns (bytes memory);
 }

--- a/src/mocks/FlashBorrowerMock.sol
+++ b/src/mocks/FlashBorrowerMock.sol
@@ -19,8 +19,9 @@ contract FlashBorrowerMock is IBlueFlashLoanCallback {
         BLUE.flashLoan(token, amount, data);
     }
 
-    function onBlueFlashLoan(address token, uint256 amount, bytes calldata) external {
+    function onBlueFlashLoan(address token, uint256 amount, bytes calldata) external returns (bytes memory) {
         require(msg.sender == address(BLUE));
         ERC20(token).safeApprove(address(BLUE), amount);
+        return hex"";
     }
 }

--- a/test/forge/Blue.t.sol
+++ b/test/forge/Blue.t.sol
@@ -910,8 +910,9 @@ contract BlueTest is
         return hex"";
     }
 
-    function onBlueFlashLoan(address token, uint256 amount, bytes calldata) external {
+    function onBlueFlashLoan(address token, uint256 amount, bytes calldata) external returns (bytes memory) {
         ERC20(token).approve(address(blue), amount);
+        return hex"";
     }
 }
 


### PR DESCRIPTION
- ~~(1) Specify a receiver: https://github.com/morpho-labs/blue/pull/121#issuecomment-1649698642~~
- (2) Callbacks returning data: https://github.com/morpho-labs/blue/pull/168#issuecomment-1649583264

IMO:
- (1) adds too much complexity
- (2) is ok to implement

~~Question about (1): should we transfer the funds to the contract called or to `msg.sender`?~~