### PR TITLE
refactor: use early return in `_accrueInterests`

### DIFF
--- a/src/Blue.sol
+++ b/src/Blue.sol
@@ -387,10 +387,6 @@ contract Blue is IBlue {
 
         if (elapsed == 0) return;
 
-        lastUpdate[id] = block.timestamp;
-
-        if (totalBorrow[id] == 0) return;
-
         uint256 borrowRate = IIrm(market.irm).borrowRate(market);
         uint256 accruedInterests = totalBorrow[id].mulWadDown(borrowRate.wTaylorCompounded(elapsed));
         totalBorrow[id] += accruedInterests;
@@ -404,6 +400,8 @@ contract Blue is IBlue {
             supplyShares[id][feeRecipient] += feeShares;
             totalSupplyShares[id] += feeShares;
         }
+
+        lastUpdate[id] = block.timestamp;
 
         emit AccrueInterests(id, borrowRate, accruedInterests, feeShares);
     }


### PR DESCRIPTION
## Pull request

Use early return instead of wrapping multiple lines of code with a if block.

This eases the code reading

⚠️ PR Update

The `totalBorrow[id] != 0` is not useful. All the logic is ok since you're adding 0 interests. 
The only consideration of letting all the logic wrapped is in case of a non-borrowed market, you'll Emit an AccrueInterest event with 0 interest generated, which is an edge case in fact.

So I suggest just to add `0` if the market is not borrowed