### PR TITLE
refactor: homogenize `IBlue` with `Blue` naming

### DIFF
--- a/src/interfaces/IBlue.sol
+++ b/src/interfaces/IBlue.sol
@@ -115,7 +115,7 @@ interface IBlue is IFlashLender {
     function liquidate(Market memory market, address borrower, uint256 seized, bytes memory data) external;
     function flashLoan(address token, uint256 amount, bytes calldata data) external;
 
-    function setAuthorization(address manager, bool isAllowed) external;
+    function setAuthorization(address authorized, bool newIsAuthorized) external;
     function setAuthorization(
         address authorizer,
         address authorized,


### PR DESCRIPTION
## Pull request

- `IBlue` has an outdated naming for `setAuthorization`