### PR TITLE
refactor: `setAuthorization` => `setAuthorizationWithSig`

### DIFF
--- a/src/Blue.sol
+++ b/src/Blue.sol
@@ -328,8 +328,14 @@ contract Blue is IBlue {
 
     // Authorizations.
 
+    function setAuthorization(address authorized, bool newIsAuthorized) external {
+        isAuthorized[msg.sender][authorized] = newIsAuthorized;
+
+        emit SetAuthorization(msg.sender, msg.sender, authorized, newIsAuthorized);
+    }
+
     /// @dev The signature is malleable, but it has no impact on the security here.
-    function setAuthorization(
+    function setAuthorizationWithSig(
         address authorizer,
         address authorized,
         bool newIsAuthorized,
@@ -351,12 +357,6 @@ contract Blue is IBlue {
         isAuthorized[authorizer][authorized] = newIsAuthorized;
 
         emit SetAuthorization(msg.sender, authorizer, authorized, newIsAuthorized);
-    }
-
-    function setAuthorization(address authorized, bool newIsAuthorized) external {
-        isAuthorized[msg.sender][authorized] = newIsAuthorized;
-
-        emit SetAuthorization(msg.sender, msg.sender, authorized, newIsAuthorized);
     }
 
     function _isSenderAuthorized(address user) internal view returns (bool) {

--- a/src/interfaces/IBlue.sol
+++ b/src/interfaces/IBlue.sol
@@ -116,7 +116,7 @@ interface IBlue is IFlashLender {
     function flashLoan(address token, uint256 amount, bytes calldata data) external;
 
     function setAuthorization(address authorized, bool newIsAuthorized) external;
-    function setAuthorization(
+    function setAuthorizationWithSig(
         address authorizer,
         address authorized,
         bool newIsAuthorized,

--- a/test/forge/Blue.t.sol
+++ b/test/forge/Blue.t.sol
@@ -826,7 +826,7 @@ contract BlueTest is
         Signature memory sig;
         (sig.v, sig.r, sig.s) = vm.sign(privateKey, digest);
 
-        blue.setAuthorization(
+        blue.setAuthorizationWithSig(
             authorization.authorizer, authorization.authorized, authorization.isAuthorized, authorization.deadline, sig
         );
 


### PR DESCRIPTION
## Pull request

Remove duplicated function name with different signatures to clarify the interface.

It is harder to type functions in any other language if the function name is the same but the behavior nor parameters are not. 

The workaround (used on Morpho Optimizers) is to rename offchain the function, or define a function name more explicit (`setAuthorization(address,address,bool)` instead of `setAutorization` for example) when we are interfacing blue, which is less readable.

So to clarify everything, I suggest to have a more explicit function name