### PR TITLE
refactor: separate view and non-view components of IIRM

### DIFF
--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -442,6 +442,7 @@ contract Morpho is IMorpho {
 
         if (marketTotalBorrow != 0) {
             uint256 borrowRate = IIrm(market.irm).borrowRate(market);
+            IIrm(market.irm).updateIRM(market);
             uint256 accruedInterests = marketTotalBorrow.wMulDown(borrowRate.wTaylorCompounded(elapsed));
             totalBorrow[id] = marketTotalBorrow + accruedInterests;
             totalSupply[id] += accruedInterests;

--- a/src/interfaces/IIrm.sol
+++ b/src/interfaces/IIrm.sol
@@ -9,5 +9,8 @@ import {Market} from "./IMorpho.sol";
 /// @notice Interface that IRMs used by Morpho must implement.
 interface IIrm {
     /// @notice Returns the borrow rate of a `market`.
-    function borrowRate(Market memory market) external returns (uint256);
+    function borrowRate(Market memory market) external view returns (uint256);
+
+    /// @notice Blue calls back through this function to allow the IRM to update its own state.
+    function updateIRM(Market memory market) external;
 }

--- a/src/mocks/IrmMock.sol
+++ b/src/mocks/IrmMock.sol
@@ -25,4 +25,8 @@ contract IrmMock is IIrm {
         // This is a very simple model (to refine later) where x% utilization corresponds to x% APR.
         return utilization / 365 days;
     }
+
+    function updateIRM(Market memory market) external {
+        // solhint-disable-next-line no-empty-blocks
+    }
 }


### PR DESCRIPTION
Fixes #313 

Ideally the call to the IIRM should be moved to the end of each interaction, and only called if timeElapsed != 0. But for this POC's sake to illustrate the main idea, I do not do this. Note that calling a non-view borrowRate function in the IIRM contains the exact same security and re-entrancy considerations as the current code in this PR.