### PR TITLE
Improve tests coverage

### DIFF
--- a/test/forge/integration/TestIntegrationAccrueInterests.t.sol
+++ b/test/forge/integration/TestIntegrationAccrueInterests.t.sol
@@ -7,6 +7,13 @@ contract IntegrationAccrueInterestsTest is BaseTest {
     using MathLib for uint256;
     using SharesMathLib for uint256;
 
+    function testAccrueInterestsMarketNotCreated(Market memory marketFuzz) public {
+        vm.assume(neq(market, marketFuzz));
+
+        vm.expectRevert(bytes(ErrorsLib.MARKET_NOT_CREATED));
+        morpho.accrueInterests(marketFuzz);
+    }
+
     function testAccrueInterestsNoTimeElapsed(uint256 amountSupplied, uint256 amountBorrowed) public {
         amountSupplied = bound(amountSupplied, 2, MAX_TEST_AMOUNT);
         amountBorrowed = bound(amountBorrowed, 1, amountSupplied);

--- a/test/forge/integration/TestIntegrationSupplyCollateral.t.sol
+++ b/test/forge/integration/TestIntegrationSupplyCollateral.t.sol
@@ -9,7 +9,7 @@ contract IntegrationSupplyCollateralTest is BaseTest {
 
         vm.prank(SUPPLIER);
         vm.expectRevert(bytes(ErrorsLib.MARKET_NOT_CREATED));
-        morpho.supply(marketFuzz, amount, 0, SUPPLIER, hex"");
+        morpho.supplyCollateral(marketFuzz, amount, SUPPLIER, hex"");
     }
 
     function testSupplyCollateralZeroAmount(address SUPPLIER) public {


### PR DESCRIPTION
Fixes:
- 2 missing tests (`testAccrueInterestsMarketNotCreated` & `testCreateMarketAlreadyCreated`)
- 1 erroneous test (`testSupplyCollateralMarketNotCreated`)
- (not related to the coverage) Removed some unnecessary `expectEmit` (see https://github.com/morpho-labs/morpho-blue/pull/218#discussion_r1293639456)

There is still not 100% coverage. The tool thinks that the callbacks are not tested, even though they are. If anyone has an explanation, I'm all ears.

`forge coverage`:
![image](https://github.com/morpho-labs/morpho-blue/assets/108467407/f1790c75-48b1-4036-97af-0a67ee62c0b6)

`forge coverage --report debug`:
![image](https://github.com/morpho-labs/morpho-blue/assets/108467407/7c112c4d-7118-4d7f-946c-150d31046da9)

