### PR TITLE
refactor: use more libraries

### DIFF
--- a/src/libraries/LiquidationLib.sol
+++ b/src/libraries/LiquidationLib.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import {MathLib, WAD} from "./MathLib.sol";
+import {PriceLib} from "./PriceLib.sol";
+import {UtilsLib} from "./UtilsLib.sol";
+
+/// @dev Liquidation cursor.
+uint256 constant LIQUIDATION_CURSOR = 0.3e18;
+/// @dev Max liquidation incentive factor.
+uint256 constant MAX_LIQUIDATION_INCENTIVE_FACTOR = 1.15e18;
+
+library LiquidationLib {
+    using MathLib for uint256;
+    using PriceLib for uint256;
+    using UtilsLib for uint256;
+
+    /// @dev The liquidation incentive factor is min(maxIncentiveFactor, 1/(1 - cursor(1 - lltv))).
+    function incentiveFactor(uint256 lltv) internal pure returns (uint256) {
+        return MAX_LIQUIDATION_INCENTIVE_FACTOR.min(WAD.wDivDown(WAD - LIQUIDATION_CURSOR.wMulDown(WAD - lltv)));
+    }
+
+    function toMaxBorrowable(uint256 collateralAssets, uint256 collateralPrice, uint256 lltv)
+        internal
+        pure
+        returns (uint256)
+    {
+        return collateralAssets.toBorrowableDown(collateralPrice).wMulDown(lltv);
+    }
+
+    function toMinCollateral(uint256 borrowableAssets, uint256 collateralPrice, uint256 lltv)
+        internal
+        pure
+        returns (uint256)
+    {
+        return borrowableAssets.wDivUp(lltv).toCollateralUp(collateralPrice);
+    }
+
+    function toRepaid(uint256 seized, uint256 collateralPrice, uint256 lltv) internal pure returns (uint256) {
+        return seized.toBorrowableUp(collateralPrice).wDivUp(incentiveFactor(lltv));
+    }
+
+    function toSeized(uint256 repaid, uint256 collateralPrice, uint256 lltv) internal pure returns (uint256) {
+        return repaid.wMulDown(incentiveFactor(lltv)).toCollateralDown(collateralPrice);
+    }
+}

--- a/src/libraries/MathLib.sol
+++ b/src/libraries/MathLib.sol
@@ -9,6 +9,8 @@ uint256 constant WAD = 1e18;
 /// @notice Library to manage fixed-point arithmetic.
 /// @dev Inspired by https://github.com/morpho-org/morpho-utils.
 library MathLib {
+    using MathLib for uint256;
+
     uint256 internal constant MAX_UINT256 = 2 ** 256 - 1;
 
     /// @dev (x * y) / WAD rounded down.
@@ -63,9 +65,13 @@ library MathLib {
     ///      to approximate a continuous compound interest rate: e^(nx) - 1.
     function wTaylorCompounded(uint256 x, uint256 n) internal pure returns (uint256) {
         uint256 firstTerm = x * n;
-        uint256 secondTerm = wMulDown(firstTerm, firstTerm) / 2;
-        uint256 thirdTerm = wMulDown(secondTerm, firstTerm) / 3;
+        uint256 secondTerm = firstTerm.wMulDown(firstTerm) / 2;
+        uint256 thirdTerm = secondTerm.wMulDown(firstTerm) / 3;
 
         return firstTerm + secondTerm + thirdTerm;
+    }
+
+    function accruedTaylorCompounded(uint256 amount, uint256 rate, uint256 elapsed) internal pure returns (uint256) {
+        return amount.wMulDown(rate.wTaylorCompounded(elapsed));
     }
 }

--- a/src/libraries/PriceLib.sol
+++ b/src/libraries/PriceLib.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import {MathLib} from "./MathLib.sol";
+
+/// @dev Oracle price scale.
+uint256 constant ORACLE_PRICE_SCALE = 1e36;
+
+library PriceLib {
+    using MathLib for uint256;
+
+    function toCollateralDown(uint256 borrowableAssets, uint256 collateralPrice) internal pure returns (uint256) {
+        return borrowableAssets.mulDivDown(ORACLE_PRICE_SCALE, collateralPrice);
+    }
+
+    function toCollateralUp(uint256 borrowableAssets, uint256 collateralPrice) internal pure returns (uint256) {
+        return borrowableAssets.mulDivUp(ORACLE_PRICE_SCALE, collateralPrice);
+    }
+
+    function toBorrowableDown(uint256 collateralAssets, uint256 collateralPrice) internal pure returns (uint256) {
+        return collateralAssets.mulDivDown(collateralPrice, ORACLE_PRICE_SCALE);
+    }
+
+    function toBorrowableUp(uint256 collateralAssets, uint256 collateralPrice) internal pure returns (uint256) {
+        return collateralAssets.mulDivUp(collateralPrice, ORACLE_PRICE_SCALE);
+    }
+}

--- a/src/libraries/SharesMathLib.sol
+++ b/src/libraries/SharesMathLib.sol
@@ -3,6 +3,10 @@ pragma solidity ^0.8.0;
 
 import {MathLib} from "./MathLib.sol";
 
+uint256 constant VIRTUAL_SHARES = 1e18;
+
+uint256 constant VIRTUAL_ASSETS = 1;
+
 /// @title SharesMathLib
 /// @author Morpho Labs
 /// @custom:contact security@morpho.xyz
@@ -11,10 +15,6 @@ import {MathLib} from "./MathLib.sol";
 ///      https://docs.openzeppelin.com/contracts/4.x/erc4626#inflation-attack.
 library SharesMathLib {
     using MathLib for uint256;
-
-    uint256 internal constant VIRTUAL_SHARES = 1e18;
-
-    uint256 internal constant VIRTUAL_ASSETS = 1;
 
     /// @dev Calculates the value of the given assets quoted in shares, rounding down.
     /// @dev Provided that assets <= totalAssets, this function satisfies the invariant: shares <= totalShares.

--- a/test/forge/BaseTest.sol
+++ b/test/forge/BaseTest.sol
@@ -4,6 +4,10 @@ pragma solidity ^0.8.0;
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
 
+import {PriceLib, ORACLE_PRICE_SCALE} from "src/libraries/PriceLib.sol";
+import {LiquidationLib} from "src/libraries/LiquidationLib.sol";
+import {SharesMathLib, VIRTUAL_SHARES} from "src/libraries/SharesMathLib.sol";
+
 import {SigUtils} from "test/forge/helpers/SigUtils.sol";
 import "src/Morpho.sol";
 import {ERC20Mock as ERC20} from "src/mocks/ERC20Mock.sol";
@@ -13,12 +17,13 @@ import {IrmMock as Irm} from "src/mocks/IrmMock.sol";
 contract BaseTest is Test {
     using MathLib for uint256;
     using MarketLib for Market;
+    using LiquidationLib for uint256;
 
     uint256 internal constant HIGH_COLLATERAL_AMOUNT = 1e35;
     uint256 internal constant MIN_TEST_AMOUNT = 100;
     uint256 internal constant MAX_TEST_AMOUNT = 1e28;
-    uint256 internal constant MIN_TEST_SHARES = MIN_TEST_AMOUNT * SharesMathLib.VIRTUAL_SHARES;
-    uint256 internal constant MAX_TEST_SHARES = MAX_TEST_AMOUNT * SharesMathLib.VIRTUAL_SHARES;
+    uint256 internal constant MIN_TEST_SHARES = MIN_TEST_AMOUNT * VIRTUAL_SHARES;
+    uint256 internal constant MAX_TEST_SHARES = MAX_TEST_AMOUNT * VIRTUAL_SHARES;
     uint256 internal constant MIN_COLLATERAL_PRICE = 1000;
     uint256 internal constant MAX_COLLATERAL_PRICE = 1e40;
 
@@ -130,7 +135,7 @@ contract BaseTest is Test {
         priceCollateral = bound(priceCollateral, MIN_COLLATERAL_PRICE, MAX_COLLATERAL_PRICE);
         amountBorrowed = bound(amountBorrowed, MIN_TEST_AMOUNT, MAX_TEST_AMOUNT);
 
-        uint256 minCollateral = amountBorrowed.wDivUp(market.lltv).mulDivUp(ORACLE_PRICE_SCALE, priceCollateral);
+        uint256 minCollateral = amountBorrowed.toMinCollateral(priceCollateral, market.lltv);
         // vm.assume(minCollateral <= MAX_TEST_AMOUNT);
 
         amountCollateral = bound(amountCollateral, minCollateral, max(minCollateral, MAX_TEST_AMOUNT));
@@ -146,11 +151,9 @@ contract BaseTest is Test {
         priceCollateral = bound(priceCollateral, MIN_COLLATERAL_PRICE, MAX_COLLATERAL_PRICE);
         amountBorrowed = bound(amountBorrowed, MIN_TEST_AMOUNT, MAX_TEST_AMOUNT);
 
-        uint256 maxCollateral = amountBorrowed.wDivDown(market.lltv).mulDivDown(ORACLE_PRICE_SCALE, priceCollateral);
-        vm.assume(
-            maxCollateral.mulDivDown(priceCollateral, ORACLE_PRICE_SCALE).wMulDown(market.lltv) < amountBorrowed
-                && maxCollateral > 0
-        );
+        uint256 maxCollateral =
+            (amountBorrowed - 1).wDivDown(market.lltv).mulDivDown(ORACLE_PRICE_SCALE, priceCollateral);
+        vm.assume(maxCollateral > 0);
 
         amountCollateral = bound(amountBorrowed, 1, maxCollateral);
 
@@ -163,11 +166,6 @@ contract BaseTest is Test {
 
     function _boundInvalidLltv(uint256 lltv) internal view returns (uint256) {
         return bound(lltv, WAD, type(uint256).max);
-    }
-
-    function _liquidationIncentive(uint256 lltv) internal pure returns (uint256) {
-        return
-            UtilsLib.min(MAX_LIQUIDATION_INCENTIVE_FACTOR, WAD.wDivDown(WAD - LIQUIDATION_CURSOR.wMulDown(WAD - lltv)));
     }
 
     function neq(Market memory a, Market memory b) internal pure returns (bool) {

--- a/test/forge/integration/TestIntegrationAccrueInterests.t.sol
+++ b/test/forge/integration/TestIntegrationAccrueInterests.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import "../BaseTest.sol";
 
 contract IntegrationAccrueInterestsTest is BaseTest {
+    using LiquidationLib for uint256;
     using MathLib for uint256;
     using SharesMathLib for uint256;
 
@@ -19,12 +20,10 @@ contract IntegrationAccrueInterestsTest is BaseTest {
         morpho.supply(market, amountSupplied, 0, address(this), hex"");
 
         uint256 collateralPrice = IOracle(market.oracle).price();
-        collateralToken.setBalance(BORROWER, amountBorrowed.wDivUp(LLTV).mulDivUp(ORACLE_PRICE_SCALE, collateralPrice));
+        collateralToken.setBalance(BORROWER, amountBorrowed.toMinCollateral(collateralPrice, LLTV));
 
         vm.startPrank(BORROWER);
-        morpho.supplyCollateral(
-            market, amountBorrowed.wDivUp(LLTV).mulDivUp(ORACLE_PRICE_SCALE, collateralPrice), BORROWER, hex""
-        );
+        morpho.supplyCollateral(market, amountBorrowed.toMinCollateral(collateralPrice, LLTV), BORROWER, hex"");
         morpho.borrow(market, amountBorrowed, 0, BORROWER, BORROWER);
         vm.stopPrank();
 
@@ -82,12 +81,10 @@ contract IntegrationAccrueInterestsTest is BaseTest {
         morpho.supply(market, amountSupplied, 0, address(this), hex"");
 
         uint256 collateralPrice = IOracle(market.oracle).price();
-        collateralToken.setBalance(BORROWER, amountBorrowed.wDivUp(LLTV).mulDivUp(ORACLE_PRICE_SCALE, collateralPrice));
+        collateralToken.setBalance(BORROWER, amountBorrowed.toMinCollateral(collateralPrice, LLTV));
 
         vm.startPrank(BORROWER);
-        morpho.supplyCollateral(
-            market, amountBorrowed.wDivUp(LLTV).mulDivUp(ORACLE_PRICE_SCALE, collateralPrice), BORROWER, hex""
-        );
+        morpho.supplyCollateral(market, amountBorrowed.toMinCollateral(collateralPrice, LLTV), BORROWER, hex"");
 
         morpho.borrow(market, amountBorrowed, 0, BORROWER, BORROWER);
         vm.stopPrank();
@@ -146,12 +143,10 @@ contract IntegrationAccrueInterestsTest is BaseTest {
         morpho.supply(market, amountSupplied, 0, address(this), hex"");
 
         uint256 collateralPrice = IOracle(market.oracle).price();
-        collateralToken.setBalance(BORROWER, amountBorrowed.wDivUp(LLTV).mulDivUp(ORACLE_PRICE_SCALE, collateralPrice));
+        collateralToken.setBalance(BORROWER, amountBorrowed.toMinCollateral(collateralPrice, LLTV));
 
         vm.startPrank(BORROWER);
-        morpho.supplyCollateral(
-            market, amountBorrowed.wDivUp(LLTV).mulDivUp(ORACLE_PRICE_SCALE, collateralPrice), BORROWER, hex""
-        );
+        morpho.supplyCollateral(market, amountBorrowed.toMinCollateral(collateralPrice, LLTV), BORROWER, hex"");
         morpho.borrow(market, amountBorrowed, 0, BORROWER, BORROWER);
         vm.stopPrank();
 

--- a/test/forge/integration/TestIntegrationBorrow.t.sol
+++ b/test/forge/integration/TestIntegrationBorrow.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import "../BaseTest.sol";
 
 contract IntegrationBorrowTest is BaseTest {
+    using LiquidationLib for uint256;
     using MathLib for uint256;
     using SharesMathLib for uint256;
 
@@ -150,7 +151,7 @@ contract IntegrationBorrowTest is BaseTest {
         uint256 expectedAmountBorrowed = sharesBorrowed.toAssetsDown(0, 0);
 
         uint256 expectedBorrowedValue = sharesBorrowed.toAssetsUp(expectedAmountBorrowed, sharesBorrowed);
-        uint256 minCollateral = expectedBorrowedValue.wDivUp(market.lltv).mulDivUp(ORACLE_PRICE_SCALE, priceCollateral);
+        uint256 minCollateral = expectedBorrowedValue.toMinCollateral(priceCollateral, LLTV);
         amountCollateral = bound(amountCollateral, minCollateral, max(minCollateral, MAX_TEST_AMOUNT));
 
         amountSupplied = bound(amountSupplied, expectedAmountBorrowed, MAX_TEST_AMOUNT);
@@ -226,7 +227,7 @@ contract IntegrationBorrowTest is BaseTest {
         uint256 expectedAmountBorrowed = sharesBorrowed.toAssetsDown(0, 0);
 
         uint256 expectedBorrowedValue = sharesBorrowed.toAssetsUp(expectedAmountBorrowed, sharesBorrowed);
-        uint256 minCollateral = expectedBorrowedValue.wDivUp(market.lltv).mulDivUp(ORACLE_PRICE_SCALE, priceCollateral);
+        uint256 minCollateral = expectedBorrowedValue.toMinCollateral(priceCollateral, LLTV);
         amountCollateral = bound(amountCollateral, minCollateral, max(minCollateral, MAX_TEST_AMOUNT));
 
         amountSupplied = bound(amountSupplied, expectedAmountBorrowed, MAX_TEST_AMOUNT);

--- a/test/forge/integration/TestIntegrationWithdraw.t.sol
+++ b/test/forge/integration/TestIntegrationWithdraw.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import "../BaseTest.sol";
 
 contract IntegrationWithdrawTest is BaseTest {
+    using LiquidationLib for uint256;
     using MathLib for uint256;
     using SharesMathLib for uint256;
 
@@ -67,7 +68,7 @@ contract IntegrationWithdrawTest is BaseTest {
         morpho.supply(market, amountSupplied, 0, SUPPLIER, hex"");
 
         uint256 collateralPrice = IOracle(market.oracle).price();
-        uint256 amountCollateral = amountBorrowed.wDivUp(LLTV).mulDivUp(ORACLE_PRICE_SCALE, collateralPrice);
+        uint256 amountCollateral = amountBorrowed.toMinCollateral(collateralPrice, LLTV);
 
         collateralToken.setBalance(BORROWER, amountCollateral);
 
@@ -87,7 +88,7 @@ contract IntegrationWithdrawTest is BaseTest {
         amountWithdrawn = bound(amountWithdrawn, 1, amountSupplied - amountBorrowed);
 
         uint256 collateralPrice = IOracle(market.oracle).price();
-        uint256 amountCollateral = amountBorrowed.wDivUp(LLTV).mulDivUp(ORACLE_PRICE_SCALE, collateralPrice);
+        uint256 amountCollateral = amountBorrowed.toMinCollateral(collateralPrice, LLTV);
 
         borrowableToken.setBalance(address(this), amountSupplied);
         collateralToken.setBalance(BORROWER, amountCollateral);
@@ -127,7 +128,7 @@ contract IntegrationWithdrawTest is BaseTest {
         amountBorrowed = bound(amountBorrowed, 1, amountSupplied - 1);
 
         uint256 collateralPrice = IOracle(market.oracle).price();
-        uint256 amountCollateral = amountBorrowed.wDivUp(LLTV).mulDivUp(ORACLE_PRICE_SCALE, collateralPrice);
+        uint256 amountCollateral = amountBorrowed.toMinCollateral(collateralPrice, LLTV);
 
         uint256 expectedSupplyShares = amountSupplied.toSharesDown(0, 0);
         uint256 availableLiquidity = amountSupplied - amountBorrowed;
@@ -174,7 +175,7 @@ contract IntegrationWithdrawTest is BaseTest {
         amountWithdrawn = bound(amountWithdrawn, 1, amountSupplied - amountBorrowed);
 
         uint256 collateralPrice = IOracle(market.oracle).price();
-        uint256 amountCollateral = amountBorrowed.wDivUp(LLTV).mulDivUp(ORACLE_PRICE_SCALE, collateralPrice);
+        uint256 amountCollateral = amountBorrowed.toMinCollateral(collateralPrice, LLTV);
 
         borrowableToken.setBalance(ONBEHALF, amountSupplied);
         collateralToken.setBalance(ONBEHALF, amountCollateral);
@@ -218,7 +219,7 @@ contract IntegrationWithdrawTest is BaseTest {
         amountBorrowed = bound(amountBorrowed, 1, amountSupplied - 1);
 
         uint256 collateralPrice = IOracle(market.oracle).price();
-        uint256 amountCollateral = amountBorrowed.wDivUp(LLTV).mulDivUp(ORACLE_PRICE_SCALE, collateralPrice);
+        uint256 amountCollateral = amountBorrowed.toMinCollateral(collateralPrice, LLTV);
 
         uint256 expectedSupplyShares = amountSupplied.toSharesDown(0, 0);
         uint256 availableLiquidity = amountSupplied - amountBorrowed;


### PR DESCRIPTION
This PR abstracts more logic into libraries that hold only pure math functions.

For integrators, it is really convenient to have such libraries, and it is even easier to integrate when the same libraries are used in the protocol (so that they can be sure they are using the correct functions). They contain more functions than are actually needed in the code; I know some of us may not like that.

New libraries:
- `PriceLib`: Just like how `SharesMathLib` handles all the conversions shares  <-> amounts, this library handles all the conversions borrowable <-> collateral.
- `LiquidationLib`: A library that may be useful to liquidators, gathering incentive computations, maximum borrowable, and minimum collateral needed.

Changes in current libraries:
- `SharesMathLib`: `VIRTUAL_SHARES` and `VIRTUAL_ASSETS` are moved to the top level, similar to how other constants are organized in other libraries.
- `MathLib`: Contains a new function that directly computes the compounded interest.
 
The testing suite has been updated to use these new libraries to demonstrate how convenient they can be and how they facilitate readability.

It lacks tests and NATSPEC, but I'm waiting to hear your thoughts on this refactor before proceeding any further!