### PR TITLE
chore: max optimizer runs

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,6 @@
 [profile.default]
 evm_version = 'paris'
 via-ir = true
+optimizer_runs = 4294967295
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/crates/config

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -36,7 +36,7 @@ const config: HardhatUserConfig = {
         settings: {
           optimizer: {
             enabled: true,
-            runs: 200,
+            runs: 4294967295,
           },
           viaIR: true,
           evmVersion: "paris",


### PR DESCRIPTION
Fixes #338 

See: https://docs.soliditylang.org/en/v0.8.21/internals/optimizer.html#optimizer-parameter-runs

Before:
![image](https://github.com/morpho-labs/morpho-blue/assets/74971347/c527a7ca-d570-46d8-9ad5-5fff20d0628a)

After: 
![image](https://github.com/morpho-labs/morpho-blue/assets/74971347/ff9445ce-a57e-4881-bf80-60dcdd843389)
