### PR TITLE
External getter name

### DIFF
--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -501,7 +501,7 @@ contract Morpho is IMorpho {
     /* STORAGE VIEW */
 
     /// @inheritdoc IMorpho
-    function extsload(bytes32[] calldata slots) external view returns (bytes32[] memory res) {
+    function extSloads(bytes32[] calldata slots) external view returns (bytes32[] memory res) {
         uint256 nSlots = slots.length;
 
         res = new bytes32[](nSlots);

--- a/src/interfaces/IMorpho.sol
+++ b/src/interfaces/IMorpho.sol
@@ -252,5 +252,5 @@ interface IMorpho {
     function accrueInterest(MarketParams memory marketParams) external;
 
     /// @notice Returns the data stored on the different `slots`.
-    function extsload(bytes32[] memory slots) external view returns (bytes32[] memory res);
+    function extSloads(bytes32[] memory slots) external view returns (bytes32[] memory res);
 }

--- a/src/libraries/periphery/MorphoBalancesLib.sol
+++ b/src/libraries/periphery/MorphoBalancesLib.sol
@@ -35,7 +35,7 @@ library MorphoBalancesLib {
         slots[1] = MorphoStorageLib.marketTotalBorrowAssetsAndSharesSlot(id);
         slots[2] = MorphoStorageLib.marketLastUpdateAndFeeSlot(id);
 
-        bytes32[] memory values = morpho.extsload(slots);
+        bytes32[] memory values = morpho.extSloads(slots);
         totalSupplyAssets = uint128(uint256(values[0]));
         totalSupplyShares = uint256(values[0] >> 128);
         toralBorrow = uint128(uint256(values[1]));

--- a/test/forge/integration/TestIntegrationGetter.t.sol
+++ b/test/forge/integration/TestIntegrationGetter.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import "../BaseTest.sol";
 
 contract IntegrationGetterTest is BaseTest {
-    function testExtsLoad(uint256 slot, bytes32 value0) public {
+    function testExtSloads(uint256 slot, bytes32 value0) public {
         bytes32[] memory slots = new bytes32[](2);
         slots[0] = bytes32(slot);
         slots[1] = bytes32(slot / 2);
@@ -13,7 +13,7 @@ contract IntegrationGetterTest is BaseTest {
         vm.store(address(morpho), slots[0], value0);
         vm.store(address(morpho), slots[1], value1);
 
-        bytes32[] memory values = morpho.extsload(slots);
+        bytes32[] memory values = morpho.extSloads(slots);
 
         assertEq(values.length, 2, "values.length");
         assertEq(values[0], slot > 0 ? value0 : value1, "value0");

--- a/test/forge/periphery/MorphoStorageLib.t.sol
+++ b/test/forge/periphery/MorphoStorageLib.t.sol
@@ -72,7 +72,7 @@ contract MorphoStorageLibTest is BaseTest {
         slots[14] = MorphoStorageLib.idToIrmSlot(id);
         slots[15] = MorphoStorageLib.idToLltvSlot(id);
 
-        bytes32[] memory values = morpho.extsload(slots);
+        bytes32[] memory values = morpho.extSloads(slots);
 
         assertEq(abi.decode(abi.encode(values[0]), (address)), morpho.owner());
         assertEq(abi.decode(abi.encode(values[1]), (address)), morpho.feeRecipient());


### PR DESCRIPTION
Use the capitalization that we went for, and add a final `s` to specify that it can query multiple values at once.

Related discussion in https://github.com/morpho-labs/morpho-blue/pull/367.

This refactor takes into account the normalized name of `EXTSLOAD` that we can find in the corresponding EIP and which is also used by Uniswap. 