### PR TITLE
refactor: move prettier config to `package.json`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-    "printWidth": 120,
-    "plugins": ["@trivago/prettier-plugin-sort-imports"]
-}

--- a/package.json
+++ b/package.json
@@ -52,5 +52,9 @@
     "extends": [
       "@commitlint/config-conventional"
     ]
+  },
+  "prettier": {
+    "printWidth": 120,
+    "plugins": ["@trivago/prettier-plugin-sort-imports"]
   }
 }


### PR DESCRIPTION
- It reduces the number of files at the root of the repo