### PR TITLE
docs(oracle): update natspecs

### DIFF
--- a/src/interfaces/IOracle.sol
+++ b/src/interfaces/IOracle.sol
@@ -7,8 +7,8 @@ pragma solidity >=0.5.0;
 /// @notice Interface that oracles used by Morpho must implement.
 interface IOracle {
     /// @notice Returns the price of 1 asset of collateral token quoted in 1 asset of borrowable token, scaled by 1e36.
-    /// @dev It corresponds to the price of 10^(collateral decimals) assets of collateral token quoted in
-    /// 10^(borrowable decimals) assets of borrowable token with `36 + collateral decimals - borrowable decimals`
+    /// @dev It corresponds to the price of 10**(collateral decimals) assets of collateral token quoted in
+    /// 10**(borrowable decimals) assets of borrowable token with `36 + borrowable decimals - collateral decimals`
     /// decimals of precision.
     function price() external view returns (uint256);
 }


### PR DESCRIPTION
Which highlights an additional requirement on the borrowable token: it must have less than 36 + collateral decimals @QGarchery 