### PR TITLE
Remove name in `DOMAIN_SEPARATOR`

### DIFF
--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -68,7 +68,7 @@ contract Morpho is IMorpho {
         require(newOwner != address(0), ErrorsLib.ZERO_ADDRESS);
         owner = newOwner;
 
-        DOMAIN_SEPARATOR = keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256("Morpho"), block.chainid, address(this)));
+        DOMAIN_SEPARATOR = keccak256(abi.encode(DOMAIN_TYPEHASH, block.chainid, address(this)));
     }
 
     /* MODIFIERS */

--- a/src/libraries/ConstantsLib.sol
+++ b/src/libraries/ConstantsLib.sol
@@ -14,7 +14,7 @@ uint256 constant LIQUIDATION_CURSOR = 0.3e18;
 uint256 constant MAX_LIQUIDATION_INCENTIVE_FACTOR = 1.15e18;
 
 /// @dev The EIP-712 typeHash for EIP712Domain.
-bytes32 constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+bytes32 constant DOMAIN_TYPEHASH = keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");
 
 /// @dev The EIP-712 typeHash for Authorization.
 bytes32 constant AUTHORIZATION_TYPEHASH =


### PR DESCRIPTION
The reason why we added this was to enable a simpler verification for the signer, but actually I think that this is more dangerous than anything else (a scammer could do a contract with the same `name`).

Also (chain, addr) is a unique identifier.