### PR TITLE
[Certora] Set proverargs hashingScheme to plaininjectivity 

### DIFF
--- a/certora/scripts/verifyDifficultMath.sh
+++ b/certora/scripts/verifyDifficultMath.sh
@@ -8,5 +8,6 @@ certoraRun \
     --verify MorphoHarness:certora/specs/DifficultMath.spec \
     --loop_iter 3 \
     --optimistic_loop \
+    --prover_args '-smt_hashingScheme plaininjectivity' \
     --msg "Morpho Difficult Math" \
     "$@"

--- a/certora/scripts/verifyHealth.sh
+++ b/certora/scripts/verifyHealth.sh
@@ -8,5 +8,6 @@ certoraRun \
     --verify MorphoHarness:certora/specs/Health.spec \
     --loop_iter 3 \
     --optimistic_loop \
+    --prover_args '-smt_hashingScheme plaininjectivity' \
     --msg "Morpho Health Check" \
     "$@"


### PR DESCRIPTION
This should remove a few of the timeouts we get without the option.

There should be still four timeouts left, three in stayHealthy and one for onlyAccrueInterestIncreasesBorrowRate (in liquidate).
