### PR TITLE
refactor(yarn): dont force compilation

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -16,12 +16,10 @@ wrap_comments = true
 [profile.build]
 test = "/dev/null"
 script = "/dev/null"
-force = true
 
 
 [profile.test]
 via-ir = false
-extra_output_files = []
 
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/crates/config

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "postinstall": "husky install && forge install",
     "build:forge": "FOUNDRY_PROFILE=build forge build",
-    "build:hardhat": "npx hardhat compile --force",
+    "build:hardhat": "npx hardhat compile",
     "test:forge": "FOUNDRY_PROFILE=test forge test",
     "test:forge:invariant": "FOUNDRY_MATCH_CONTRACT=InvariantTest yarn test:forge",
     "test:forge:integration": "FOUNDRY_MATCH_CONTRACT=IntegrationTest yarn test:forge",


### PR DESCRIPTION
yarn commands are easily extendable, so don't force compilation and let the dev pass `--force` if needed. it is useful in `morpho-stack` to not compile blue again everytime