### PR TITLE
fix(remappings): declare local lib context (option 1)

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,1 +1,1 @@
-forge-std/=lib/forge-std/src/
+@blue/=lib/

--- a/test/forge/BaseTest.sol
+++ b/test/forge/BaseTest.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import "forge-std/Test.sol";
-import "forge-std/console.sol";
+import "@blue/forge-std/src/Test.sol";
+import "@blue/forge-std/src/console.sol";
 
 import "src/interfaces/IMorphoCallbacks.sol";
 import {IrmMock} from "src/mocks/IrmMock.sol";

--- a/test/forge/MarketParamsLibTest.sol
+++ b/test/forge/MarketParamsLibTest.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import "forge-std/Test.sol";
+import "@blue/forge-std/src/Test.sol";
 
 import {MarketParamsLib, MarketParams, Id} from "src/libraries/MarketParamsLib.sol";
 

--- a/test/forge/libraries/MathLibTest.sol
+++ b/test/forge/libraries/MathLibTest.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import "forge-std/Test.sol";
+import "@blue/forge-std/src/Test.sol";
 
 import "src/libraries/MathLib.sol";
 import "test/forge/helpers/WadMath.sol";

--- a/test/forge/libraries/SafeTransferLibTest.sol
+++ b/test/forge/libraries/SafeTransferLibTest.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import "forge-std/Test.sol";
+import "@blue/forge-std/src/Test.sol";
 
 import "src/libraries/ErrorsLib.sol";
 import {IERC20, SafeTransferLib} from "src/libraries/SafeTransferLib.sol";

--- a/test/forge/libraries/UtilsLibTest.sol
+++ b/test/forge/libraries/UtilsLibTest.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-import "forge-std/Test.sol";
+import "@blue/forge-std/src/Test.sol";
 
 import "src/libraries/ErrorsLib.sol";
 import "src/libraries/UtilsLib.sol";


### PR DESCRIPTION
Prepended with `@` to make sure this remapping never clashes with the name of a submodule

`blue` can be renamed `morpho-blue` if you want