### PR TITLE
Fix gas cost study for liquidation?

### DIFF
--- a/test/forge/integration/LiquidateGasCostIntegrationTest.sol
+++ b/test/forge/integration/LiquidateGasCostIntegrationTest.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.0;
+
+import "../BaseTest.sol";
+
+contract LiquidateGasCostIntegrationTest is BaseTest {
+    using MathLib for uint256;
+    using MorphoLib for IMorpho;
+    using SharesMathLib for uint256;
+
+    uint256 amountSupplied;
+    uint256 amountCollateral;
+    uint256 amountBorrowed;
+    uint256 priceCollateral;
+    uint256 sharesRepaid;
+
+    function setUp() public override {
+        super.setUp();
+
+        (amountCollateral, amountBorrowed, priceCollateral) =
+            _boundUnhealthyPosition(MIN_TEST_AMOUNT, MIN_TEST_AMOUNT, 1 ether);
+
+        vm.assume(amountCollateral > 1);
+
+        uint256 liquidationIncentiveFactor = _liquidationIncentiveFactor(marketParams.lltv);
+        uint256 expectedRepaid =
+            amountCollateral.mulDivUp(priceCollateral, ORACLE_PRICE_SCALE).wDivUp(liquidationIncentiveFactor);
+
+        uint256 minBorrowed = Math.max(expectedRepaid, amountBorrowed);
+        amountBorrowed = bound(amountBorrowed, minBorrowed, Math.max(minBorrowed, MAX_TEST_AMOUNT));
+
+        amountSupplied = bound(amountSupplied, amountBorrowed, Math.max(amountBorrowed, MAX_TEST_AMOUNT));
+        _supply(amountSupplied);
+
+        loanToken.setBalance(LIQUIDATOR, amountBorrowed);
+        collateralToken.setBalance(BORROWER, amountCollateral);
+
+        oracle.setPrice(type(uint256).max / amountCollateral);
+
+        vm.startPrank(BORROWER);
+        morpho.supplyCollateral(marketParams, amountCollateral, BORROWER, hex"");
+        morpho.borrow(marketParams, amountBorrowed, 0, BORROWER, BORROWER);
+        vm.stopPrank();
+
+        oracle.setPrice(priceCollateral);
+    }
+
+    function testLiquidatePartially() public {
+        vm.prank(LIQUIDATOR);
+        morpho.liquidate(marketParams, BORROWER, amountCollateral / 2, 0, hex"");
+        assertGt(morpho.borrowShares(id, BORROWER), 0, "borrow shares");
+    }
+
+    function testLiquidateRealizeBadDebt() public {
+        vm.prank(LIQUIDATOR);
+        morpho.liquidate(marketParams, BORROWER, amountCollateral, 0, hex"");
+        assertEq(morpho.borrowShares(id, BORROWER), 0, "borrow shares");
+    }
+}

--- a/test/hardhat/Morpho.spec.ts
+++ b/test/hardhat/Morpho.spec.ts
@@ -192,6 +192,8 @@ describe("Morpho", () => {
 
       const seized = closePositions ? assets : assets / 2n;
 
+      await randomForwardTimestamp();
+
       await morpho.connect(liquidator).liquidate(marketParams, borrower.address, seized, 0, "0x");
 
       const remainingCollateral = (await morpho.position(id, borrower.address)).collateral;


### PR DESCRIPTION
Adding `randomForwardTimestamp` to have cold slots before the liquidation.

## `closePosition = false`:

<img width="953" alt="Screenshot 2023-10-10 at 17 47 13" src="https://github.com/morpho-org/morpho-blue/assets/44097430/c7be0d6e-521b-4050-852c-99fb46698d16">


## `closePosition = true`:

<img width="899" alt="Screenshot 2023-10-10 at 17 48 56" src="https://github.com/morpho-org/morpho-blue/assets/44097430/b14a6e32-8efd-4747-84d4-f92e0e30d954">

## Question

Should I change the comment btw? "// Realize the bad debt if needed. Note that it saves ~3k gas to do it."
