### PR TITLE
Calculate correct amount of shares

### DIFF
--- a/test/forge/integration/LiquidateIntegrationTest.sol
+++ b/test/forge/integration/LiquidateIntegrationTest.sol
@@ -151,9 +151,10 @@ contract LiquidateIntegrationTest is BaseTest {
         uint256 expectedBorrowShares = amountBorrowed.toSharesUp(0, 0);
         uint256 maxRepaidShares = amountCollateral.mulDivDown(priceCollateral, ORACLE_PRICE_SCALE).wDivDown(
             _liquidationIncentiveFactor(marketParams.lltv)
-        );
+        ).toSharesDown(amountBorrowed, expectedBorrowShares);
         vm.assume(maxRepaidShares != 0);
-        sharesRepaid = bound(sharesRepaid, 1, Math.min(maxRepaidShares, expectedBorrowShares));
+
+        sharesRepaid = bound(sharesRepaid, 1, Math.min(expectedBorrowShares, maxRepaidShares));
         uint256 expectedRepaid = sharesRepaid.toAssetsUp(amountBorrowed, expectedBorrowShares);
         uint256 expectedSeized = expectedRepaid.wMulDown(_liquidationIncentiveFactor(marketParams.lltv)).mulDivDown(
             ORACLE_PRICE_SCALE, priceCollateral


### PR DESCRIPTION
[Reference](https://discord.com/channels/1072909701601308672/1155839514862964808/1162277843447853097)

I think we did not notice this since the amount of assets is lower than the number of shares and so here the `Math.min()` was capping the maximum number of shares to repay to a lower value. 

