### PR TITLE
Feat/add npm ci

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -2,11 +2,6 @@ name: Publish on NPM
 
 on:
   workflow_dispatch:
-    inputs:
-      version_type:
-        description: 'Version to release, in valid semver format'
-        required: true
-        type: string
 
 jobs:
   publish-to-npm:
@@ -16,21 +11,8 @@ jobs:
       name: npm
       url: https://www.npmjs.com/package/@morpho-org/morpho-blue
     steps:
-
-      - name: Validate semver format of the provided version
-        run: |
-          if [[ ! "${{ github.event.inputs.version_type }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "Invalid semver format. Please provide a valid semver format (v1.2.3)"
-              exit 1
-          fi
-
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Bump package.json version
-        run: |
-          version_type=$(echo "${{ steps.determine_version.outputs.version_type }}")
-          yarn version --new-version ${version_type} --no-git-tag-version
 
       - name: Publish to npm
         run: |

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -8,15 +8,13 @@ on:
         required: true
         type: string
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: true
-
-
 jobs:
   publish-to-npm:
     name: Publish to NPM
     runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/@morpho-org/morpho-blue
     steps:
 
       - name: Validate semver format of the provided version

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,0 +1,40 @@
+name: Publish on NPM
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version to release, in valid semver format'
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+
+jobs:
+  publish-to-npm:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Validate semver format of the provided version
+        run: |
+          if [[ ! "${{ github.event.inputs.version_type }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Invalid semver format. Please provide a valid semver format (v1.2.3)"
+              exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Bump package.json version
+        run: |
+          version_type=$(echo "${{ steps.determine_version.outputs.version_type }}")
+          yarn version --new-version ${version_type} --no-git-tag-version
+
+      - name: Publish to npm
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+          yarn publish --access public

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@morpho-org/morpho-blue",
   "description": "Morpho Blue Protocol",
   "license": "BUSL-1.1",
-  "version": "v1.0.0",
+  "version": "0.1.0",
   "files": [
     "src",
     "README.md",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 {
-  "name": "morpho-blue",
+  "name": "@morpho-org/morpho-blue",
   "description": "Morpho Blue Protocol",
   "license": "BUSL-1.1",
-  "version": "1.0.0",
+  "version": "v1.0.0",
+  "files": [
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "postinstall": "husky install && forge install",
     "build:forge": "FOUNDRY_PROFILE=build forge build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,15 @@
 {
-    "compilerOptions": {
-      "target": "esnext",
-      "strict": true,
-      "esModuleInterop": true,
-      "rootDir": ".",
-      "baseUrl": ".",
-      "outDir": "dist",
-      "moduleResolution": "nodenext",
-      "resolveJsonModule": true,
-      "declaration": true
-    },
-    "include": ["types", "test/hardhat"],
-    "files": ["./hardhat.config.ts"]
+  "compilerOptions": {
+    "target": "es6",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "outDir": "dist",
+    "baseUrl": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["types", "test/hardhat"],
+  "files": ["hardhat.config.ts"]
 }


### PR DESCRIPTION
## Motivation
Morpho blue does not have any dependency (forge or npm). We can use the contracts in both `hardhat` and `foundry` projects. 
If we want to ease Blue integrations to devs not working on Foundry, we can publish the package to npm.

However, publication to npm is a critical action that needs to have security about when and who can trigger the CI.

## Solution
- The workflow can be triggered by hand.
- 've not defined an auto versioning not to have to allow the action to push on main the bumped version (security reason).
- However, it is up to the person triggering the workflow to define a correct version. 
- There is a check to verify the semver format.
- I have created a GitHub environment (named npm) that is scoping the deployment to the main branch only and that requires administrators' reviewals before publishing on npm