### PR TITLE
Add return bytes to flashloan callback

### DIFF
--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -399,12 +399,12 @@ contract Morpho is IMorpho {
     /* FLASH LOANS */
 
     /// @inheritdoc IMorpho
-    function flashLoan(address token, uint256 assets, bytes calldata data) external {
+    function flashLoan(address token, uint256 assets, bytes calldata data) external returns (bytes memory resultData) {
         IERC20(token).safeTransfer(msg.sender, assets);
 
         emit EventsLib.FlashLoan(msg.sender, token, assets);
 
-        IMorphoFlashLoanCallback(msg.sender).onMorphoFlashLoan(assets, data);
+        resultData = IMorphoFlashLoanCallback(msg.sender).onMorphoFlashLoan(assets, data);
 
         IERC20(token).safeTransferFrom(msg.sender, address(this), assets);
     }

--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -404,7 +404,7 @@ contract Morpho is IMorpho {
 
         emit EventsLib.FlashLoan(msg.sender, token, assets);
 
-        resultData = IMorphoFlashLoanCallback(msg.sender).onMorphoFlashLoan(assets, data);
+        returnData = IMorphoFlashLoanCallback(msg.sender).onMorphoFlashLoan(assets, data);
 
         IERC20(token).safeTransferFrom(msg.sender, address(this), assets);
     }

--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -399,7 +399,7 @@ contract Morpho is IMorpho {
     /* FLASH LOANS */
 
     /// @inheritdoc IMorpho
-    function flashLoan(address token, uint256 assets, bytes calldata data) external returns (bytes memory resultData) {
+    function flashLoan(address token, uint256 assets, bytes calldata data) external returns (bytes memory returnData) {
         IERC20(token).safeTransfer(msg.sender, assets);
 
         emit EventsLib.FlashLoan(msg.sender, token, assets);

--- a/src/interfaces/IMorpho.sol
+++ b/src/interfaces/IMorpho.sol
@@ -280,8 +280,8 @@ interface IMorpho {
     /// @param token The token to flash loan.
     /// @param assets The amount of assets to flash loan.
     /// @param data Arbitrary data to pass to the `onMorphoFlashLoan` callback.
-    /// @return resultData Arbitrary data returned by the callback.
-    function flashLoan(address token, uint256 assets, bytes calldata data) external returns (bytes memory resultData);
+    /// @return returnData Arbitrary data returned by the callback.
+    function flashLoan(address token, uint256 assets, bytes calldata data) external returns (bytes memory returnData);
 
     /// @notice Sets the authorization for `authorized` to manage `msg.sender`'s positions.
     /// @param authorized The authorized address.

--- a/src/interfaces/IMorpho.sol
+++ b/src/interfaces/IMorpho.sol
@@ -280,7 +280,8 @@ interface IMorpho {
     /// @param token The token to flash loan.
     /// @param assets The amount of assets to flash loan.
     /// @param data Arbitrary data to pass to the `onMorphoFlashLoan` callback.
-    function flashLoan(address token, uint256 assets, bytes calldata data) external;
+    /// @return resultData Arbitrary data returned by the callback.
+    function flashLoan(address token, uint256 assets, bytes calldata data) external returns (bytes memory resultData);
 
     /// @notice Sets the authorization for `authorized` to manage `msg.sender`'s positions.
     /// @param authorized The authorized address.

--- a/src/interfaces/IMorphoCallbacks.sol
+++ b/src/interfaces/IMorphoCallbacks.sol
@@ -48,6 +48,6 @@ interface IMorphoFlashLoanCallback {
     /// @dev The callback is called only if data is not empty.
     /// @param assets The amount of assets that was flash loaned.
     /// @param data Arbitrary data passed to the `flashLoan` function.
-    /// @return resultData Arbitrary data returned by the callback.
-    function onMorphoFlashLoan(uint256 assets, bytes calldata data) external returns (bytes memory resultData);
+    /// @return returnData Arbitrary data returned by the callback.
+    function onMorphoFlashLoan(uint256 assets, bytes calldata data) external returns (bytes memory returnData);
 }

--- a/src/interfaces/IMorphoCallbacks.sol
+++ b/src/interfaces/IMorphoCallbacks.sol
@@ -48,5 +48,6 @@ interface IMorphoFlashLoanCallback {
     /// @dev The callback is called only if data is not empty.
     /// @param assets The amount of assets that was flash loaned.
     /// @param data Arbitrary data passed to the `flashLoan` function.
-    function onMorphoFlashLoan(uint256 assets, bytes calldata data) external;
+    /// @return resultData Arbitrary data returned by the callback.
+    function onMorphoFlashLoan(uint256 assets, bytes calldata data) external returns (bytes memory resultData);
 }

--- a/src/mocks/FlashBorrowerMock.sol
+++ b/src/mocks/FlashBorrowerMock.sol
@@ -12,7 +12,7 @@ contract FlashBorrowerMock is IMorphoFlashLoanCallback {
         MORPHO = newMorpho;
     }
 
-    function flashLoan(address token, uint256 assets, bytes calldata data) external returns (bytes memory resultData) {
+    function flashLoan(address token, uint256 assets, bytes calldata data) external returns (bytes memory returnData) {
         return MORPHO.flashLoan(token, assets, data);
     }
 

--- a/src/mocks/FlashBorrowerMock.sol
+++ b/src/mocks/FlashBorrowerMock.sol
@@ -16,10 +16,10 @@ contract FlashBorrowerMock is IMorphoFlashLoanCallback {
         return MORPHO.flashLoan(token, assets, data);
     }
 
-    function onMorphoFlashLoan(uint256 assets, bytes calldata data) external returns (bytes memory returnData) {
+    function onMorphoFlashLoan(uint256 assets, bytes calldata data) external returns (bytes memory) {
         require(msg.sender == address(MORPHO));
         address token = abi.decode(data, (address));
         IERC20(token).approve(address(MORPHO), assets);
-        resultData = "";
+        return "";
     }
 }

--- a/src/mocks/FlashBorrowerMock.sol
+++ b/src/mocks/FlashBorrowerMock.sol
@@ -16,7 +16,7 @@ contract FlashBorrowerMock is IMorphoFlashLoanCallback {
         return MORPHO.flashLoan(token, assets, data);
     }
 
-    function onMorphoFlashLoan(uint256 assets, bytes calldata data) external returns (bytes memory resultData) {
+    function onMorphoFlashLoan(uint256 assets, bytes calldata data) external returns (bytes memory returnData) {
         require(msg.sender == address(MORPHO));
         address token = abi.decode(data, (address));
         IERC20(token).approve(address(MORPHO), assets);

--- a/src/mocks/FlashBorrowerMock.sol
+++ b/src/mocks/FlashBorrowerMock.sol
@@ -12,7 +12,7 @@ contract FlashBorrowerMock is IMorphoFlashLoanCallback {
         MORPHO = newMorpho;
     }
 
-    function flashLoan(address token, uint256 assets, bytes calldata data) external returns (bytes memory returnData) {
+    function flashLoan(address token, uint256 assets, bytes calldata data) external returns (bytes memory) {
         return MORPHO.flashLoan(token, assets, data);
     }
 

--- a/src/mocks/FlashBorrowerMock.sol
+++ b/src/mocks/FlashBorrowerMock.sol
@@ -12,13 +12,14 @@ contract FlashBorrowerMock is IMorphoFlashLoanCallback {
         MORPHO = newMorpho;
     }
 
-    function flashLoan(address token, uint256 assets, bytes calldata data) external {
-        MORPHO.flashLoan(token, assets, data);
+    function flashLoan(address token, uint256 assets, bytes calldata data) external returns (bytes memory resultData) {
+        return MORPHO.flashLoan(token, assets, data);
     }
 
-    function onMorphoFlashLoan(uint256 assets, bytes calldata data) external {
+    function onMorphoFlashLoan(uint256 assets, bytes calldata data) external returns (bytes memory resultData) {
         require(msg.sender == address(MORPHO));
         address token = abi.decode(data, (address));
         IERC20(token).approve(address(MORPHO), assets);
+        resultData = "";
     }
 }

--- a/test/forge/integration/CallbacksIntegrationTest.sol
+++ b/test/forge/integration/CallbacksIntegrationTest.sol
@@ -60,7 +60,7 @@ contract CallbacksIntegrationTest is
         }
     }
 
-    function onMorphoFlashLoan(uint256 amount, bytes memory data) external returns (bytes memory resultData) {
+    function onMorphoFlashLoan(uint256 amount, bytes memory data) external returns (bytes memory returnData) {
         require(msg.sender == address(morpho));
         bytes4 selector;
         (selector, data) = abi.decode(data, (bytes4, bytes));

--- a/test/forge/integration/CallbacksIntegrationTest.sol
+++ b/test/forge/integration/CallbacksIntegrationTest.sol
@@ -83,7 +83,7 @@ contract CallbacksIntegrationTest is
             morpho.flashLoan(address(loanToken), amount, abi.encode(this.testFlashLoan.selector, hex""));
 
         assertEq(loanToken.balanceOf(address(morpho)), amount, "balanceOf");
-        assertEq(resultData, "Arbitrary data!", "resultData");
+        assertEq(returnData, "Arbitrary data!", "returnData");
     }
 
     function testFlashLoanShouldRevertIfNotReimbursed(uint256 amount) public {

--- a/test/forge/integration/CallbacksIntegrationTest.sol
+++ b/test/forge/integration/CallbacksIntegrationTest.sol
@@ -79,7 +79,7 @@ contract CallbacksIntegrationTest is
         loanToken.setBalance(address(this), amount);
         morpho.supply(marketParams, amount, 0, address(this), hex"");
 
-        bytes memory resultData =
+        bytes memory returnData =
             morpho.flashLoan(address(loanToken), amount, abi.encode(this.testFlashLoan.selector, hex""));
 
         assertEq(loanToken.balanceOf(address(morpho)), amount, "balanceOf");

--- a/test/forge/integration/CallbacksIntegrationTest.sol
+++ b/test/forge/integration/CallbacksIntegrationTest.sol
@@ -67,7 +67,7 @@ contract CallbacksIntegrationTest is
         if (selector == this.testFlashLoan.selector) {
             assertEq(loanToken.balanceOf(address(this)), amount);
             loanToken.approve(address(morpho), amount);
-            resultData = "Arbitrary data!";
+            returnData = "Arbitrary data!";
         }
     }
 


### PR DESCRIPTION
Adds return bytes to the flash loan callback and the flash loan function so a callback user can pass data back to itself without using storage.