### PR TITLE
Remove IRM call skip

### DIFF
--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -454,25 +454,22 @@ contract Morpho is IMorpho {
 
         if (elapsed == 0) return;
 
-        if (market[id].totalBorrowAssets != 0) {
-            uint256 borrowRate = IIrm(marketParams.irm).borrowRate(marketParams, market[id]);
-            uint256 interest = market[id].totalBorrowAssets.wMulDown(borrowRate.wTaylorCompounded(elapsed));
-            market[id].totalBorrowAssets += interest.toUint128();
-            market[id].totalSupplyAssets += interest.toUint128();
+        uint256 borrowRate = IIrm(marketParams.irm).borrowRate(marketParams, market[id]);
+        uint256 interest = market[id].totalBorrowAssets.wMulDown(borrowRate.wTaylorCompounded(elapsed));
+        market[id].totalBorrowAssets += interest.toUint128();
+        market[id].totalSupplyAssets += interest.toUint128();
 
-            uint256 feeShares;
-            if (market[id].fee != 0) {
-                uint256 feeAmount = interest.wMulDown(market[id].fee);
-                // The fee amount is subtracted from the total supply in this calculation to compensate for the fact
-                // that total supply is already increased by the full interest (including the fee amount).
-                feeShares =
-                    feeAmount.toSharesDown(market[id].totalSupplyAssets - feeAmount, market[id].totalSupplyShares);
-                position[id][feeRecipient].supplyShares += feeShares;
-                market[id].totalSupplyShares += feeShares.toUint128();
-            }
-
-            emit EventsLib.AccrueInterest(id, borrowRate, interest, feeShares);
+        uint256 feeShares;
+        if (market[id].fee != 0) {
+            uint256 feeAmount = interest.wMulDown(market[id].fee);
+            // The fee amount is subtracted from the total supply in this calculation to compensate for the fact
+            // that total supply is already increased by the full interest (including the fee amount).
+            feeShares = feeAmount.toSharesDown(market[id].totalSupplyAssets - feeAmount, market[id].totalSupplyShares);
+            position[id][feeRecipient].supplyShares += feeShares;
+            market[id].totalSupplyShares += feeShares.toUint128();
         }
+
+        emit EventsLib.AccrueInterest(id, borrowRate, interest, feeShares);
 
         // Safe "unchecked" cast.
         market[id].lastUpdate = uint128(block.timestamp);

--- a/src/libraries/periphery/MorphoBalancesLib.sol
+++ b/src/libraries/periphery/MorphoBalancesLib.sol
@@ -45,7 +45,7 @@ library MorphoBalancesLib {
 
         uint256 elapsed = block.timestamp - market.lastUpdate;
 
-        if (elapsed != 0) {
+        if (elapsed != 0 && market.totalBorrowAssets != 0) {
             uint256 borrowRate = IIrm(marketParams.irm).borrowRateView(marketParams, market);
             uint256 interest = market.totalBorrowAssets.wMulDown(borrowRate.wTaylorCompounded(elapsed));
             market.totalBorrowAssets += interest.toUint128();

--- a/src/libraries/periphery/MorphoBalancesLib.sol
+++ b/src/libraries/periphery/MorphoBalancesLib.sol
@@ -45,6 +45,7 @@ library MorphoBalancesLib {
 
         uint256 elapsed = block.timestamp - market.lastUpdate;
 
+        // Skipped if elapsed == 0 of if totalBorrowAssets == 0 because interest would be null.
         if (elapsed != 0 && market.totalBorrowAssets != 0) {
             uint256 borrowRate = IIrm(marketParams.irm).borrowRateView(marketParams, market);
             uint256 interest = market.totalBorrowAssets.wMulDown(borrowRate.wTaylorCompounded(elapsed));

--- a/src/libraries/periphery/MorphoBalancesLib.sol
+++ b/src/libraries/periphery/MorphoBalancesLib.sol
@@ -45,7 +45,7 @@ library MorphoBalancesLib {
 
         uint256 elapsed = block.timestamp - market.lastUpdate;
 
-        if (elapsed != 0 && market.totalBorrowAssets != 0) {
+        if (elapsed != 0) {
             uint256 borrowRate = IIrm(marketParams.irm).borrowRateView(marketParams, market);
             uint256 interest = market.totalBorrowAssets.wMulDown(borrowRate.wTaylorCompounded(elapsed));
             market.totalBorrowAssets += interest.toUint128();

--- a/src/mocks/IrmMock.sol
+++ b/src/mocks/IrmMock.sol
@@ -11,6 +11,7 @@ contract IrmMock is IIrm {
 
     function borrowRateView(MarketParams memory, Market memory market) public pure returns (uint256) {
         if (market.totalSupplyAssets == 0) return 0;
+
         uint256 utilization = market.totalBorrowAssets.wDivDown(market.totalSupplyAssets);
 
         // Divide by the number of seconds in a year.

--- a/src/mocks/IrmMock.sol
+++ b/src/mocks/IrmMock.sol
@@ -10,6 +10,7 @@ contract IrmMock is IIrm {
     using MathLib for uint128;
 
     function borrowRateView(MarketParams memory, Market memory market) public pure returns (uint256) {
+        if (market.totalSupplyAssets == 0) return 0;
         uint256 utilization = market.totalBorrowAssets.wDivDown(market.totalSupplyAssets);
 
         // Divide by the number of seconds in a year.


### PR DESCRIPTION
I think that we should remove the IRM call skip bacause (https://github.com/morpho-org/morpho-blue/issues/460):
- it makes building IRMs more complex (the dev has to think about this)
- it creates some weird cases in our first IRM (https://github.com/morpho-labs/morpho-blue-irm/pull/54#discussion_r1380565416)
- we have in mind not so crazy scenarios where one might want to do something particular when a market stayed empty of with only supply for a certain period of time (that actually includes my second point) (https://github.com/morpho-org/morpho-blue/issues/460#issue-1875682799)
- it simplifies Morpho Blue
- we don't care about this opti, interacting with a market without any borrow is super rare
- https://github.com/cantinasec/review-morpho-blue-1/issues/42