### PR TITLE
Signature of `idToMarketParams` to return a struct

### DIFF
--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -66,7 +66,7 @@ contract Morpho is IMorphoStaticTyping {
     mapping(address => mapping(address => bool)) public isAuthorized;
     /// @inheritdoc IMorphoBase
     mapping(address => uint256) public nonce;
-    /// @inheritdoc IMorphoBase
+    /// @inheritdoc IMorphoStaticTyping
     mapping(Id => MarketParams) public idToMarketParams;
 
     /* CONSTRUCTOR */

--- a/src/interfaces/IMorpho.sol
+++ b/src/interfaces/IMorpho.sol
@@ -77,14 +77,6 @@ interface IMorphoBase {
     /// @notice The `authorizer`'s current nonce. Used to prevent replay attacks with EIP-712 signatures.
     function nonce(address authorizer) external view returns (uint256);
 
-    /// @notice The market params corresponding to `id`.
-    /// @dev This mapping is not used in Morpho. It is there to enable reducing the cost associated to calldata on layer
-    /// 2s by creating a wrapper contract with functions that take `id` as input instead of `marketParams`.
-    function idToMarketParams(Id id)
-        external
-        view
-        returns (address loanToken, address collateralToken, address oracle, address irm, uint256 lltv);
-
     /// @notice Sets `newOwner` as `owner` of the contract.
     /// @dev Warning: No two-step transfer ownership.
     /// @dev Warning: The owner can be set to the zero address.
@@ -318,6 +310,14 @@ interface IMorphoStaticTyping is IMorphoBase {
             uint128 lastUpdate,
             uint128 fee
         );
+
+    /// @notice The market params corresponding to `id`.
+    /// @dev This mapping is not used in Morpho. It is there to enable reducing the cost associated to calldata on layer
+    /// 2s by creating a wrapper contract with functions that take `id` as input instead of `marketParams`.
+    function idToMarketParams(Id id)
+        external
+        view
+        returns (address loanToken, address collateralToken, address oracle, address irm, uint256 lltv);
 }
 
 /// @title IMorpho
@@ -336,4 +336,9 @@ interface IMorpho is IMorphoBase {
     /// @dev Warning: `m.totalSupplyShares` does not contain the accrued shares by `feeRecipient` since the last
     /// interest accrual.
     function market(Id id) external view returns (Market memory m);
+
+    /// @notice The market params corresponding to `id`.
+    /// @dev This mapping is not used in Morpho. It is there to enable reducing the cost associated to calldata on layer
+    /// 2s by creating a wrapper contract with functions that take `id` as input instead of `marketParams`.
+    function idToMarketParams(Id id) external view returns (MarketParams memory);
 }

--- a/test/forge/integration/CreateMarketIntegrationTest.sol
+++ b/test/forge/integration/CreateMarketIntegrationTest.sol
@@ -84,13 +84,12 @@ contract CreateMarketIntegrationTest is BaseTest {
         morpho.createMarket(marketParamsFuzz);
         vm.stopPrank();
 
-        (address loanToken, address collateralToken, address oracle, address irm, uint256 lltv) =
-            morpho.idToMarketParams(marketParamsFuzzId);
+        MarketParams memory params = morpho.idToMarketParams(marketParamsFuzzId);
 
-        assertEq(marketParamsFuzz.loanToken, loanToken, "loanToken != loanToken");
-        assertEq(marketParamsFuzz.collateralToken, collateralToken, "collateralToken != collateralToken");
-        assertEq(marketParamsFuzz.oracle, oracle, "oracle != oracle");
-        assertEq(marketParamsFuzz.irm, irm, "irm != irm");
-        assertEq(marketParamsFuzz.lltv, lltv, "lltv != lltv");
+        assertEq(marketParamsFuzz.loanToken, params.loanToken, "loanToken != loanToken");
+        assertEq(marketParamsFuzz.collateralToken, params.collateralToken, "collateralToken != collateralToken");
+        assertEq(marketParamsFuzz.oracle, params.oracle, "oracle != oracle");
+        assertEq(marketParamsFuzz.irm, params.irm, "irm != irm");
+        assertEq(marketParamsFuzz.lltv, params.lltv, "lltv != lltv");
     }
 }

--- a/test/forge/libraries/periphery/MorphoStorageLibTest.sol
+++ b/test/forge/libraries/periphery/MorphoStorageLibTest.sol
@@ -93,17 +93,12 @@ contract MorphoStorageLibTest is BaseTest {
         assertEq(abi.decode(abi.encode(values[9]), (bool)), morpho.isAuthorized(authorizer, BORROWER));
         assertEq(uint256(values[10]), morpho.nonce(authorizer));
 
-        (
-            address expectedloanToken,
-            address expectedCollateralToken,
-            address expectedOracle,
-            address expectedIrm,
-            uint256 expectedLltv
-        ) = morpho.idToMarketParams(id);
-        assertEq(abi.decode(abi.encode(values[11]), (address)), expectedloanToken);
-        assertEq(abi.decode(abi.encode(values[12]), (address)), expectedCollateralToken);
-        assertEq(abi.decode(abi.encode(values[13]), (address)), expectedOracle);
-        assertEq(abi.decode(abi.encode(values[14]), (address)), expectedIrm);
-        assertEq(uint256(values[15]), expectedLltv);
+        MarketParams memory expectedParams = morpho.idToMarketParams(id);
+
+        assertEq(abi.decode(abi.encode(values[11]), (address)), expectedParams.loanToken);
+        assertEq(abi.decode(abi.encode(values[12]), (address)), expectedParams.collateralToken);
+        assertEq(abi.decode(abi.encode(values[13]), (address)), expectedParams.oracle);
+        assertEq(abi.decode(abi.encode(values[14]), (address)), expectedParams.irm);
+        assertEq(uint256(values[15]), expectedParams.lltv);
     }
 }


### PR DESCRIPTION
This is something we have missed in #567 