### PR TITLE
feat(irm): skip address(0)

### DIFF
--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -477,7 +477,7 @@ contract Morpho is IMorphoStaticTyping {
     function _accrueInterest(MarketParams memory marketParams, Id id) internal {
         uint256 elapsed = block.timestamp - market[id].lastUpdate;
 
-        if (elapsed == 0) return;
+        if (elapsed == 0 || marketParams.irm == address(0)) return;
 
         uint256 borrowRate = IIrm(marketParams.irm).borrowRate(marketParams, market[id]);
         uint256 interest = market[id].totalBorrowAssets.wMulDown(borrowRate.wTaylorCompounded(elapsed));

--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -160,7 +160,7 @@ contract Morpho is IMorphoStaticTyping {
         emit EventsLib.CreateMarket(id, marketParams);
 
         // Call to initialize the IRM in case it is stateful.
-        IIrm(marketParams.irm).borrowRate(marketParams, market[id]);
+        if (marketParams.irm != address(0)) IIrm(marketParams.irm).borrowRate(marketParams, market[id]);
     }
 
     /* SUPPLY MANAGEMENT */

--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -475,9 +475,10 @@ contract Morpho is IMorphoStaticTyping {
     /// @dev Accrues interest for the given market `marketParams`.
     /// @dev Assumes that the inputs `marketParams` and `id` match.
     function _accrueInterest(MarketParams memory marketParams, Id id) internal {
-        uint256 elapsed = block.timestamp - market[id].lastUpdate;
+        if (marketParams.irm == address(0)) return;
 
-        if (elapsed == 0 || marketParams.irm == address(0)) return;
+        uint256 elapsed = block.timestamp - market[id].lastUpdate;
+        if (elapsed == 0) return;
 
         uint256 borrowRate = IIrm(marketParams.irm).borrowRate(marketParams, market[id]);
         uint256 interest = market[id].totalBorrowAssets.wMulDown(borrowRate.wTaylorCompounded(elapsed));

--- a/src/Morpho.sol
+++ b/src/Morpho.sol
@@ -483,27 +483,28 @@ contract Morpho is IMorphoStaticTyping {
     /// @dev Accrues interest for the given market `marketParams`.
     /// @dev Assumes that the inputs `marketParams` and `id` match.
     function _accrueInterest(MarketParams memory marketParams, Id id) internal {
-        if (marketParams.irm == address(0)) return;
-
         uint256 elapsed = block.timestamp - market[id].lastUpdate;
         if (elapsed == 0) return;
 
-        uint256 borrowRate = IIrm(marketParams.irm).borrowRate(marketParams, market[id]);
-        uint256 interest = market[id].totalBorrowAssets.wMulDown(borrowRate.wTaylorCompounded(elapsed));
-        market[id].totalBorrowAssets += interest.toUint128();
-        market[id].totalSupplyAssets += interest.toUint128();
+        if (marketParams.irm != address(0)) {
+            uint256 borrowRate = IIrm(marketParams.irm).borrowRate(marketParams, market[id]);
+            uint256 interest = market[id].totalBorrowAssets.wMulDown(borrowRate.wTaylorCompounded(elapsed));
+            market[id].totalBorrowAssets += interest.toUint128();
+            market[id].totalSupplyAssets += interest.toUint128();
 
-        uint256 feeShares;
-        if (market[id].fee != 0) {
-            uint256 feeAmount = interest.wMulDown(market[id].fee);
-            // The fee amount is subtracted from the total supply in this calculation to compensate for the fact
-            // that total supply is already increased by the full interest (including the fee amount).
-            feeShares = feeAmount.toSharesDown(market[id].totalSupplyAssets - feeAmount, market[id].totalSupplyShares);
-            position[id][feeRecipient].supplyShares += feeShares;
-            market[id].totalSupplyShares += feeShares.toUint128();
+            uint256 feeShares;
+            if (market[id].fee != 0) {
+                uint256 feeAmount = interest.wMulDown(market[id].fee);
+                // The fee amount is subtracted from the total supply in this calculation to compensate for the fact
+                // that total supply is already increased by the full interest (including the fee amount).
+                feeShares =
+                    feeAmount.toSharesDown(market[id].totalSupplyAssets - feeAmount, market[id].totalSupplyShares);
+                position[id][feeRecipient].supplyShares += feeShares;
+                market[id].totalSupplyShares += feeShares.toUint128();
+            }
+
+            emit EventsLib.AccrueInterest(id, borrowRate, interest, feeShares);
         }
-
-        emit EventsLib.AccrueInterest(id, borrowRate, interest, feeShares);
 
         // Safe "unchecked" cast.
         market[id].lastUpdate = uint128(block.timestamp);

--- a/src/libraries/periphery/MorphoBalancesLib.sol
+++ b/src/libraries/periphery/MorphoBalancesLib.sol
@@ -36,13 +36,12 @@ library MorphoBalancesLib {
         returns (uint256, uint256, uint256, uint256)
     {
         Id id = marketParams.id();
-
         Market memory market = morpho.market(id);
 
         uint256 elapsed = block.timestamp - market.lastUpdate;
 
-        // Skipped if elapsed == 0 or if totalBorrowAssets == 0 because interest would be null.
-        if (elapsed != 0 && market.totalBorrowAssets != 0) {
+        // Skipped if elapsed == 0 or totalBorrowAssets == 0 or irm == address(0) because interest would be null.
+        if (elapsed != 0 && market.totalBorrowAssets != 0 && marketParams.irm != address(0)) {
             uint256 borrowRate = IIrm(marketParams.irm).borrowRateView(marketParams, market);
             uint256 interest = market.totalBorrowAssets.wMulDown(borrowRate.wTaylorCompounded(elapsed));
             market.totalBorrowAssets += interest.toUint128();

--- a/src/libraries/periphery/MorphoBalancesLib.sol
+++ b/src/libraries/periphery/MorphoBalancesLib.sol
@@ -40,7 +40,7 @@ library MorphoBalancesLib {
 
         uint256 elapsed = block.timestamp - market.lastUpdate;
 
-        // Skipped if elapsed == 0 or totalBorrowAssets == 0 or irm == address(0) because interest would be null.
+        // Skipped if elapsed == 0 or totalBorrowAssets == 0 because interest would be null, or if irm == address(0).
         if (elapsed != 0 && market.totalBorrowAssets != 0 && marketParams.irm != address(0)) {
             uint256 borrowRate = IIrm(marketParams.irm).borrowRateView(marketParams, market);
             uint256 interest = market.totalBorrowAssets.wMulDown(borrowRate.wTaylorCompounded(elapsed));

--- a/test/forge/BaseTest.sol
+++ b/test/forge/BaseTest.sol
@@ -135,7 +135,7 @@ contract BaseTest is Test {
     }
 
     /// @dev Bounds the fuzzing input to a realistic number of blocks.
-    function _boundBlocks(uint256 blocks) internal view returns (uint256) {
+    function _boundBlocks(uint256 blocks) internal pure returns (uint256) {
         return bound(blocks, 1, type(uint32).max);
     }
 
@@ -200,7 +200,7 @@ contract BaseTest is Test {
         return (amountCollateral, amountBorrowed, priceCollateral);
     }
 
-    function _boundTestLltv(uint256 lltv) internal view returns (uint256) {
+    function _boundTestLltv(uint256 lltv) internal pure returns (uint256) {
         return bound(lltv, MIN_TEST_LLTV, MAX_TEST_LLTV);
     }
 
@@ -384,7 +384,7 @@ contract BaseTest is Test {
         return Math.min(MAX_LIQUIDATION_INCENTIVE_FACTOR, WAD.wDivDown(WAD - LIQUIDATION_CURSOR.wMulDown(WAD - lltv)));
     }
 
-    function _boundValidLltv(uint256 lltv) internal view returns (uint256) {
+    function _boundValidLltv(uint256 lltv) internal pure returns (uint256) {
         return bound(lltv, 0, WAD - 1);
     }
 

--- a/test/forge/BaseTest.sol
+++ b/test/forge/BaseTest.sol
@@ -82,7 +82,9 @@ contract BaseTest is Test {
         irm = new IrmMock();
 
         vm.startPrank(OWNER);
+        morpho.enableIrm(address(0));
         morpho.enableIrm(address(irm));
+        morpho.enableLltv(0);
         morpho.setFeeRecipient(FEE_RECIPIENT);
         vm.stopPrank();
 

--- a/test/forge/integration/AccrueInterestIntegrationTest.sol
+++ b/test/forge/integration/AccrueInterestIntegrationTest.sol
@@ -15,6 +15,18 @@ contract AccrueInterestIntegrationTest is BaseTest {
         morpho.accrueInterest(marketParamsFuzz);
     }
 
+    function testAccrueInterestIrmZero(MarketParams memory marketParamsFuzz, uint256 blocks) public {
+        marketParamsFuzz.irm = address(0);
+        marketParamsFuzz.lltv = 0;
+        blocks = _boundBlocks(blocks);
+
+        morpho.createMarket(marketParamsFuzz);
+
+        _forward(blocks);
+
+        morpho.accrueInterest(marketParamsFuzz);
+    }
+
     function testAccrueInterestNoTimeElapsed(uint256 amountSupplied, uint256 amountBorrowed) public {
         uint256 collateralPrice = oracle.price();
         uint256 amountCollateral;

--- a/test/forge/integration/CreateMarketIntegrationTest.sol
+++ b/test/forge/integration/CreateMarketIntegrationTest.sol
@@ -9,7 +9,7 @@ contract CreateMarketIntegrationTest is BaseTest {
     using MarketParamsLib for MarketParams;
 
     function testCreateMarketWithNotEnabledIrmAndNotEnabledLltv(MarketParams memory marketParamsFuzz) public {
-        vm.assume(marketParamsFuzz.irm != address(irm) && marketParamsFuzz.lltv != marketParams.lltv);
+        vm.assume(!morpho.isIrmEnabled(marketParamsFuzz.irm) && !morpho.isLltvEnabled(marketParamsFuzz.lltv));
 
         vm.prank(OWNER);
         vm.expectRevert(bytes(ErrorsLib.IRM_NOT_ENABLED));
@@ -17,11 +17,12 @@ contract CreateMarketIntegrationTest is BaseTest {
     }
 
     function testCreateMarketWithNotEnabledIrmAndEnabledLltv(MarketParams memory marketParamsFuzz) public {
-        vm.assume(marketParamsFuzz.irm != address(irm));
+        vm.assume(!morpho.isIrmEnabled(marketParamsFuzz.irm));
+
         marketParamsFuzz.lltv = _boundValidLltv(marketParamsFuzz.lltv);
 
         vm.startPrank(OWNER);
-        if (marketParamsFuzz.lltv != marketParams.lltv) morpho.enableLltv(marketParamsFuzz.lltv);
+        if (!morpho.isLltvEnabled(marketParamsFuzz.lltv)) morpho.enableLltv(marketParamsFuzz.lltv);
 
         vm.expectRevert(bytes(ErrorsLib.IRM_NOT_ENABLED));
         morpho.createMarket(marketParamsFuzz);
@@ -29,10 +30,10 @@ contract CreateMarketIntegrationTest is BaseTest {
     }
 
     function testCreateMarketWithEnabledIrmAndNotEnabledLltv(MarketParams memory marketParamsFuzz) public {
-        vm.assume(marketParamsFuzz.lltv != marketParams.lltv);
+        vm.assume(!morpho.isLltvEnabled(marketParamsFuzz.lltv));
 
         vm.startPrank(OWNER);
-        if (marketParamsFuzz.irm != marketParams.irm) morpho.enableIrm(marketParamsFuzz.irm);
+        if (!morpho.isIrmEnabled(marketParamsFuzz.irm)) morpho.enableIrm(marketParamsFuzz.irm);
 
         vm.expectRevert(bytes(ErrorsLib.LLTV_NOT_ENABLED));
         morpho.createMarket(marketParamsFuzz);
@@ -44,8 +45,8 @@ contract CreateMarketIntegrationTest is BaseTest {
         Id marketParamsFuzzId = marketParamsFuzz.id();
 
         vm.startPrank(OWNER);
-        if (marketParamsFuzz.irm != marketParams.irm) morpho.enableIrm(marketParamsFuzz.irm);
-        if (marketParamsFuzz.lltv != marketParams.lltv) morpho.enableLltv(marketParamsFuzz.lltv);
+        if (!morpho.isIrmEnabled(marketParamsFuzz.irm)) morpho.enableIrm(marketParamsFuzz.irm);
+        if (!morpho.isLltvEnabled(marketParamsFuzz.lltv)) morpho.enableLltv(marketParamsFuzz.lltv);
 
         vm.mockCall(marketParamsFuzz.irm, abi.encodeWithSelector(IIrm.borrowRate.selector), abi.encode(0));
 
@@ -66,10 +67,12 @@ contract CreateMarketIntegrationTest is BaseTest {
         marketParamsFuzz.lltv = _boundValidLltv(marketParamsFuzz.lltv);
 
         vm.startPrank(OWNER);
-        if (marketParamsFuzz.irm != marketParams.irm) morpho.enableIrm(marketParamsFuzz.irm);
-        if (marketParamsFuzz.lltv != marketParams.lltv) morpho.enableLltv(marketParamsFuzz.lltv);
+        if (!morpho.isIrmEnabled(marketParamsFuzz.irm)) morpho.enableIrm(marketParamsFuzz.irm);
+        if (!morpho.isLltvEnabled(marketParamsFuzz.lltv)) morpho.enableLltv(marketParamsFuzz.lltv);
 
-        vm.mockCall(marketParamsFuzz.irm, abi.encodeWithSelector(IIrm.borrowRate.selector), abi.encode(0));
+        if (marketParamsFuzz.irm != address(0)) {
+            vm.mockCall(marketParamsFuzz.irm, abi.encodeWithSelector(IIrm.borrowRate.selector), abi.encode(0));
+        }
 
         morpho.createMarket(marketParamsFuzz);
 
@@ -83,8 +86,8 @@ contract CreateMarketIntegrationTest is BaseTest {
         Id marketParamsFuzzId = marketParamsFuzz.id();
 
         vm.startPrank(OWNER);
-        if (marketParamsFuzz.irm != marketParams.irm) morpho.enableIrm(marketParamsFuzz.irm);
-        if (marketParamsFuzz.lltv != marketParams.lltv) morpho.enableLltv(marketParamsFuzz.lltv);
+        if (!morpho.isIrmEnabled(marketParamsFuzz.irm)) morpho.enableIrm(marketParamsFuzz.irm);
+        if (!morpho.isLltvEnabled(marketParamsFuzz.lltv)) morpho.enableLltv(marketParamsFuzz.lltv);
 
         vm.mockCall(marketParamsFuzz.irm, abi.encodeWithSelector(IIrm.borrowRate.selector), abi.encode(0));
 

--- a/test/forge/integration/OnlyOwnerIntegrationTest.sol
+++ b/test/forge/integration/OnlyOwnerIntegrationTest.sol
@@ -59,7 +59,7 @@ contract OnlyOwnerIntegrationTest is BaseTest {
     }
 
     function testEnableIrm(address irmFuzz) public {
-        vm.assume(irmFuzz != address(irm));
+        vm.assume(!morpho.isIrmEnabled(irmFuzz));
 
         vm.prank(OWNER);
         vm.expectEmit(true, true, true, true, address(morpho));
@@ -94,7 +94,8 @@ contract OnlyOwnerIntegrationTest is BaseTest {
 
     function testEnableLltv(uint256 lltvFuzz) public {
         lltvFuzz = _boundValidLltv(lltvFuzz);
-        vm.assume(lltvFuzz != marketParams.lltv);
+
+        vm.assume(!morpho.isLltvEnabled(lltvFuzz));
 
         vm.prank(OWNER);
         vm.expectEmit(true, true, true, true, address(morpho));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2020",
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "outDir": "dist",


### PR DESCRIPTION
- Fixes #631 

it takes 85k gas to create an idle market while it takes 175k gas to create a standard market

and here is the gas diff between standard markets (left) and idle markets (right):
<img width="826" alt="image" src="https://github.com/morpho-org/morpho-blue/assets/3147812/4eac3f65-ee29-4312-af3a-873ed790b6f2">

on avg, it costs -9k to supply/withdraw to/from an idle market