### PR TITLE
[Certora] Complete the idToMarketParams invariant

### DIFF
--- a/certora/harness/MorphoHarness.sol
+++ b/certora/harness/MorphoHarness.sol
@@ -18,6 +18,10 @@ contract MorphoHarness is Morpho {
         return MAX_FEE;
     }
 
+    function toMarketParams(Id id) external view returns (MarketParams memory) {
+        return idToMarketParams[id];
+    }
+
     function totalSupplyAssets(Id id) external view returns (uint256) {
         return market[id].totalSupplyAssets;
     }

--- a/certora/specs/ConsistentState.spec
+++ b/certora/specs/ConsistentState.spec
@@ -98,10 +98,16 @@ invariant sumBorrowSharesCorrect(MorphoHarness.Id id)
 invariant borrowLessThanSupply(MorphoHarness.Id id)
     totalBorrowAssets(id) <= totalSupplyAssets(id);
 
-// This invariant is useful in the following rule, to link an id back to a market.
-invariant marketInvariant(MorphoHarness.Id id)
+// Check correctness of applying idToMarketParams() to an identifier.
+invariant marketParamsOfHash(MorphoHarness.Id id)
     isCreated(id) =>
     libId(toMarketParams(id)) == id;
+
+// Check correctness of applying id() to a market params.
+// This invariant is useful in the following rule, to link an id back to a market.
+invariant hashOfMarketParams(MorphoHarness.MarketParams marketParams)
+    isCreated(libId(marketParams)) =>
+    toMarketParams(libId(marketParams)) == marketParams;
 
 // Check that the idle amount on the singleton is greater to the sum amount, that is the sum over all the markets of the total supply plus the total collateral minus the total borrow.
 invariant idleAmountLessThanBalance(address token)
@@ -109,31 +115,31 @@ invariant idleAmountLessThanBalance(address token)
 {
     // Safe requires on the sender because the contract cannot call the function itself.
     preserved supply(MorphoHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, bytes data) with (env e) {
-        requireInvariant marketInvariant(libId(marketParams));
+        requireInvariant hashOfMarketParams(marketParams);
         require e.msg.sender != currentContract;
     }
     preserved withdraw(MorphoHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, address receiver) with (env e) {
-        requireInvariant marketInvariant(libId(marketParams));
+        requireInvariant hashOfMarketParams(marketParams);
         require e.msg.sender != currentContract;
     }
     preserved borrow(MorphoHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, address receiver) with (env e) {
-        requireInvariant marketInvariant(libId(marketParams));
+        requireInvariant hashOfMarketParams(marketParams);
         require e.msg.sender != currentContract;
     }
     preserved repay(MorphoHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, bytes data) with (env e) {
-        requireInvariant marketInvariant(libId(marketParams));
+        requireInvariant hashOfMarketParams(marketParams);
         require e.msg.sender != currentContract;
     }
     preserved supplyCollateral(MorphoHarness.MarketParams marketParams, uint256 assets, address onBehalf, bytes data) with (env e) {
-        requireInvariant marketInvariant(libId(marketParams));
+        requireInvariant hashOfMarketParams(marketParams);
         require e.msg.sender != currentContract;
     }
     preserved withdrawCollateral(MorphoHarness.MarketParams marketParams, uint256 assets, address onBehalf, address receiver) with (env e) {
-        requireInvariant marketInvariant(libId(marketParams));
+        requireInvariant hashOfMarketParams(marketParams);
         require e.msg.sender != currentContract;
     }
     preserved liquidate(MorphoHarness.MarketParams marketParams, address _b, uint256 shares, uint256 receiver, bytes data) with (env e) {
-        requireInvariant marketInvariant(libId(marketParams));
+        requireInvariant hashOfMarketParams(marketParams);
         require e.msg.sender != currentContract;
     }
 }

--- a/certora/specs/ConsistentState.spec
+++ b/certora/specs/ConsistentState.spec
@@ -99,13 +99,13 @@ invariant borrowLessThanSupply(MorphoHarness.Id id)
     totalBorrowAssets(id) <= totalSupplyAssets(id);
 
 // Check correctness of applying idToMarketParams() to an identifier.
-invariant marketParamsOfHash(MorphoHarness.Id id)
+invariant hashOfMarketParamsOf(MorphoHarness.Id id)
     isCreated(id) =>
     libId(toMarketParams(id)) == id;
 
 // Check correctness of applying id() to a market params.
 // This invariant is useful in the following rule, to link an id back to a market.
-invariant hashOfMarketParams(MorphoHarness.MarketParams marketParams)
+invariant marketParamsOfHashOf(MorphoHarness.MarketParams marketParams)
     isCreated(libId(marketParams)) =>
     toMarketParams(libId(marketParams)).loanToken == marketParams.loanToken &&
     toMarketParams(libId(marketParams)).collateralToken == marketParams.collateralToken &&
@@ -119,31 +119,31 @@ invariant idleAmountLessThanBalance(address token)
 {
     // Safe requires on the sender because the contract cannot call the function itself.
     preserved supply(MorphoHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, bytes data) with (env e) {
-        requireInvariant hashOfMarketParams(marketParams);
+        requireInvariant marketParamsOfHashOf(marketParams);
         require e.msg.sender != currentContract;
     }
     preserved withdraw(MorphoHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, address receiver) with (env e) {
-        requireInvariant hashOfMarketParams(marketParams);
+        requireInvariant marketParamsOfHashOf(marketParams);
         require e.msg.sender != currentContract;
     }
     preserved borrow(MorphoHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, address receiver) with (env e) {
-        requireInvariant hashOfMarketParams(marketParams);
+        requireInvariant marketParamsOfHashOf(marketParams);
         require e.msg.sender != currentContract;
     }
     preserved repay(MorphoHarness.MarketParams marketParams, uint256 assets, uint256 shares, address onBehalf, bytes data) with (env e) {
-        requireInvariant hashOfMarketParams(marketParams);
+        requireInvariant marketParamsOfHashOf(marketParams);
         require e.msg.sender != currentContract;
     }
     preserved supplyCollateral(MorphoHarness.MarketParams marketParams, uint256 assets, address onBehalf, bytes data) with (env e) {
-        requireInvariant hashOfMarketParams(marketParams);
+        requireInvariant marketParamsOfHashOf(marketParams);
         require e.msg.sender != currentContract;
     }
     preserved withdrawCollateral(MorphoHarness.MarketParams marketParams, uint256 assets, address onBehalf, address receiver) with (env e) {
-        requireInvariant hashOfMarketParams(marketParams);
+        requireInvariant marketParamsOfHashOf(marketParams);
         require e.msg.sender != currentContract;
     }
     preserved liquidate(MorphoHarness.MarketParams marketParams, address _b, uint256 shares, uint256 receiver, bytes data) with (env e) {
-        requireInvariant hashOfMarketParams(marketParams);
+        requireInvariant marketParamsOfHashOf(marketParams);
         require e.msg.sender != currentContract;
     }
 }

--- a/certora/specs/ConsistentState.spec
+++ b/certora/specs/ConsistentState.spec
@@ -107,7 +107,11 @@ invariant marketParamsOfHash(MorphoHarness.Id id)
 // This invariant is useful in the following rule, to link an id back to a market.
 invariant hashOfMarketParams(MorphoHarness.MarketParams marketParams)
     isCreated(libId(marketParams)) =>
-    toMarketParams(libId(marketParams)) == marketParams;
+    toMarketParams(libId(marketParams)).loanToken == marketParams.loanToken &&
+    toMarketParams(libId(marketParams)).collateralToken == marketParams.collateralToken &&
+    toMarketParams(libId(marketParams)).oracle == marketParams.oracle &&
+    toMarketParams(libId(marketParams)).lltv == marketParams.lltv &&
+    toMarketParams(libId(marketParams)).irm == marketParams.irm;
 
 // Check that the idle amount on the singleton is greater to the sum amount, that is the sum over all the markets of the total supply plus the total collateral minus the total borrow.
 invariant idleAmountLessThanBalance(address token)


### PR DESCRIPTION
This PR completes the invariant about `idToMarketParams`. This invariant is splitted into 2 Certora invariants (`hashOfMarketParams` and `marketParamsOfHash`), and states that: `idToMarketParams()` and `id()` are reciprocal functions, under the condition that the corresponding market has been created