### PR TITLE
Improve bounds in tests

### DIFF
--- a/test/forge/BaseTest.sol
+++ b/test/forge/BaseTest.sol
@@ -139,13 +139,6 @@ contract BaseTest is Test {
         return bound(blocks, 1, type(uint32).max);
     }
 
-    /// @dev Bounds the fuzzing input to a non-zero address.
-    /// @dev This function should be used in place of `vm.assume` in invariant test handler functions:
-    /// https://github.com/foundry-rs/foundry/issues/4190.
-    function _boundAddressNotZero(address input) internal view virtual returns (address) {
-        return address(uint160(bound(uint256(uint160(input)), 1, type(uint160).max)));
-    }
-
     function _supply(uint256 amount) internal {
         loanToken.setBalance(address(this), amount);
         morpho.supply(marketParams, amount, 0, address(this), hex"");
@@ -194,7 +187,7 @@ contract BaseTest is Test {
 
         uint256 maxCollateral =
             amountBorrowed.wDivDown(marketParams.lltv).mulDivDown(ORACLE_PRICE_SCALE, priceCollateral);
-        amountCollateral = bound(amountBorrowed, 0, Math.min(maxCollateral, MAX_COLLATERAL_ASSETS));
+        amountCollateral = bound(amountCollateral, 0, Math.min(maxCollateral, MAX_COLLATERAL_ASSETS));
 
         vm.assume(amountCollateral > 0);
         return (amountCollateral, amountBorrowed, priceCollateral);

--- a/test/forge/invariant/MorphoInvariantTest.sol
+++ b/test/forge/invariant/MorphoInvariantTest.sol
@@ -235,7 +235,7 @@ contract MorphoInvariantTest is InvariantTest {
     function withdrawAssetsOnBehalfNoRevert(uint256 marketSeed, uint256 assets, uint256 onBehalfSeed, address receiver)
         external
     {
-        receiver = _boundAddressNotZero(receiver);
+        vm.assume(receiver != address(0));
 
         MarketParams memory _marketParams = _randomMarket(marketSeed);
 
@@ -251,7 +251,7 @@ contract MorphoInvariantTest is InvariantTest {
     function borrowAssetsOnBehalfNoRevert(uint256 marketSeed, uint256 assets, uint256 onBehalfSeed, address receiver)
         external
     {
-        receiver = _boundAddressNotZero(receiver);
+        vm.assume(receiver != address(0));
 
         MarketParams memory _marketParams = _randomMarket(marketSeed);
 
@@ -305,7 +305,7 @@ contract MorphoInvariantTest is InvariantTest {
         uint256 onBehalfSeed,
         address receiver
     ) external {
-        receiver = _boundAddressNotZero(receiver);
+        vm.assume(receiver != address(0));
 
         MarketParams memory _marketParams = _randomMarket(marketSeed);
 


### PR DESCRIPTION
Fixes:
- #680 
- [now it is possible](https://github.com/foundry-rs/foundry/issues/4190) to `vm.assume` in invariants