### PR TITLE
[Certora] Improve assets accounting specification

### DIFF
--- a/certora/specs/ExactMath.spec
+++ b/certora/specs/ExactMath.spec
@@ -55,7 +55,7 @@ rule repayAllResetsBorrowExchangeRate(env e, MorphoHarness.MarketParams marketPa
     mathint sharesAfter = virtualTotalBorrowShares(id);
 
     assert assetsAfter == 1;
-    // There are at least as many shares as virtual shares.
+    // There are at least as many shares as virtual shares, by definition of virtualTotalBorrowShares.
 }
 
 // There should be no profit from supply followed immediately by withdraw.


### PR DESCRIPTION
Improve assets accounting specification so that we don't have to assume that supply, borrow, and supplyCollateral start with an empty position