### PR TITLE
Update formal verification

### DIFF
--- a/certora/confs/LibSummary.conf
+++ b/certora/confs/LibSummary.conf
@@ -6,7 +6,7 @@
     "verify": "MorphoHarness:certora/specs/LibSummary.spec",
     "rule_sanity": "basic",
     "prover_args": [
-        "-useBitVectorTheory",
+        "-smt_bitVectorTheory true"
     ],
     "server": "production",
     "msg": "Morpho Blue Lib Summary"

--- a/test/halmos/HalmosTest.sol
+++ b/test/halmos/HalmosTest.sol
@@ -13,7 +13,7 @@ import "../../src/Morpho.sol";
 import "../../src/libraries/ConstantsLib.sol";
 import {MorphoLib} from "../../src/libraries/periphery/MorphoLib.sol";
 
-/// @custom:halmos --symbolic-storage --solver-timeout-assertion 0
+/// @custom:halmos --solver-timeout-assertion 0
 contract HalmosTest is SymTest, Test {
     using MorphoLib for IMorpho;
     using MarketParamsLib for MarketParams;
@@ -47,6 +47,10 @@ contract HalmosTest is SymTest, Test {
         morpho.enableLltv(lltv);
         morpho.createMarket(marketParams);
         vm.stopPrank();
+    }
+
+    function setUpSymbolic() public {
+        svm.enableSymbolicStorage(address(this));
     }
 
     // Call Morpho, assuming interacting with only the defined market for performance reasons.


### PR DESCRIPTION
This PR:
- updates to the new CVL version, the change being the syntax for declaring the use of the bitvector theory
- updates to the new Halmos version, with a new way to declare symbolic storage