### PR TITLE
Tests: fix CI with precise computations

### DIFF
--- a/test/forge/BaseTest.sol
+++ b/test/forge/BaseTest.sol
@@ -330,13 +330,15 @@ contract BaseTest is Test {
     {
         Id _id = _marketParams.id();
 
-        uint256 collateral = morpho.collateral(_id, borrower);
         uint256 collateralPrice = IOracle(_marketParams.oracle).price();
-        uint256 maxRepaidAssets = morpho.expectedBorrowAssets(_marketParams, borrower);
+        uint256 borrowShares = morpho.borrowShares(_id, borrower);
+        (,, uint256 totalBorrowAssets, uint256 totalBorrowShares) = morpho.expectedMarketBalances(_marketParams);
+        uint256 maxRepaidAssets = borrowShares.toAssetsDown(totalBorrowAssets, totalBorrowShares);
         uint256 maxSeizedAssets = maxRepaidAssets.wMulDown(_liquidationIncentiveFactor(_marketParams.lltv)).mulDivDown(
             ORACLE_PRICE_SCALE, collateralPrice
         );
 
+        uint256 collateral = morpho.collateral(_id, borrower);
         return bound(seizedAssets, 0, Math.min(collateral, maxSeizedAssets));
     }
 

--- a/test/forge/BaseTest.sol
+++ b/test/forge/BaseTest.sol
@@ -189,7 +189,7 @@ contract BaseTest is Test {
             amountBorrowed.wDivDown(marketParams.lltv).mulDivDown(ORACLE_PRICE_SCALE, priceCollateral);
         amountCollateral = bound(amountCollateral, 0, Math.min(maxCollateral, MAX_COLLATERAL_ASSETS));
 
-        vm.assume(amountCollateral > 0);
+        vm.assume(amountCollateral > 0 && amountCollateral < maxCollateral);
         return (amountCollateral, amountBorrowed, priceCollateral);
     }
 

--- a/test/forge/invariant/MorphoInvariantTest.sol
+++ b/test/forge/invariant/MorphoInvariantTest.sol
@@ -170,12 +170,11 @@ contract MorphoInvariantTest is InvariantTest {
     {
         uint256 collateralPrice = oracle.price();
         uint256 liquidationIncentiveFactor = _liquidationIncentiveFactor(_marketParams.lltv);
-        Market memory _market = morpho.market(_marketParams.id());
+        (,, uint256 totalBorrowAssets, uint256 totalBorrowShares) = morpho.expectedMarketBalances(_marketParams);
         uint256 seizedAssetsQuoted = seizedAssets.mulDivUp(collateralPrice, ORACLE_PRICE_SCALE);
-        uint256 repaidShares = seizedAssetsQuoted.wDivUp(liquidationIncentiveFactor).toSharesUp(
-            _market.totalBorrowAssets, _market.totalBorrowShares
-        );
-        uint256 repaidAssets = repaidShares.toAssetsUp(_market.totalBorrowAssets, _market.totalBorrowShares);
+        uint256 repaidShares =
+            seizedAssetsQuoted.wDivUp(liquidationIncentiveFactor).toSharesUp(totalBorrowAssets, totalBorrowShares);
+        uint256 repaidAssets = repaidShares.toAssetsUp(totalBorrowAssets, totalBorrowShares);
 
         loanToken.setBalance(msg.sender, repaidAssets);
 


### PR DESCRIPTION
This PR:
- fixes, in [f178c58](https://github.com/morpho-org/morpho-blue/pull/695/commits/f178c5876f40ea26f540ef6189fa9e85f919debb),  the computation of `repaidAssets` in `_liquidateSeizedAssets`, where interest not being accrued can underestimate it. Note that then it would potentially revert with "insufficient balance" in the following `liquidate`. 
<details><summary> See failing test to add to <tt>MorphoInvariantTest.sol</tt> </summary>

```solidity

    function testPreciseRepaidAssets() public {
        bool success;
        vm.prank(USER);
        (success,) = address(this).call(
            abi.encodeCall(
                this.supplySharesOnBehalfNoRevert,
                (
                    12120140710833733770211937208572361813353,
                    115792089237316195423570985008687907853269984665640564039457584007913129639932,
                    47864507797463465527
                )
            )
        );
        require(success);
        vm.prank(USER);
        (success,) = address(this).call(
            abi.encodeCall(
                this.supplyCollateralOnBehalfNoRevert,
                (
                    6435052175716277,
                    2228508671749618012310924141807912904392434873641473790,
                    9172044389146582702825330639391132781
                )
            )
        );
        require(success);
        vm.prank(USER);
        (success,) = address(this).call(
            abi.encodeCall(
                this.borrowAssetsOnBehalfNoRevert,
                (
                    1037090935628654632096113780633684768273947888827139171,
                    115792089237316195423570985008687907853269984665640564039457584007913129639932,
                    92919271977526577528324241,
                    0xb9524FC61bB10455497B76eCb47f7E15f5745c7b
                )
            )
        );
        require(success);
        vm.prank(USER);
        (success,) =
            address(this).call(abi.encodeCall(this.mine, (1917255564262442434629483470867958936496970738886927248333)));
        require(success);
        vm.prank(USER);
        (success,) = address(this).call(
            abi.encodeCall(
                this.liquidateSeizedAssetsNoRevert,
                (
                    423100602366647113405520187643810494979637824649807,
                    387663186081816078315953644541605829239672,
                    2906615577213273566318347175683901325413471477552651909
                )
            )
        );
        require(success);
    }
```
</details>

- fixes, in [fc6793a](https://github.com/morpho-org/morpho-blue/pull/695/commits/fc6793a8ede377a6fc6c501de9ea53ba9e270c1f), the `_boundUnhealthyPosition` function to exclude some edge case positions that were actually healthy. For a failing test, run `testBorrowUnhealthyPosition(1000, 800, 800, 1e36);`
- fixes, in [208c886](https://github.com/morpho-org/morpho-blue/pull/695/commits/208c886d813cf24e96776d06ae27d02e46252c08), the `_boundLiquidateSeizedAssets` function that was rounding up the `maxRepaidAssets` 

<details><summary> See failing test to add to <tt>MorphoInvariantTest.sol</tt> </summary>

```solidity
    function testUnderflowShares() public {
        bool success;
        vm.prank(USER);
        (success,) = address(this).call(
            abi.encodeCall(
                this.supplyAssetsOnBehalfNoRevert,
                (5359, 2834887728753290660080060877037723411257078492004434445635685037311818465281, 5492)
            )
        );
        require(success);
        vm.prank(USER);
        (success,) = address(this).call(
            abi.encodeCall(
                this.supplyCollateralOnBehalfNoRevert,
                (
                    13564749995715475,
                    289569068587302794245905088352847419974621660102028416637799895,
                    93568447518652389288497189907082257029069294440600267233672740108057536
                )
            )
        );
        require(success);
        vm.prank(USER);
        (success,) = address(this).call(
            abi.encodeCall(
                this.borrowAssetsOnBehalfNoRevert,
                (21253, 37687424321302508251177020996897486395182, 783, 0x00000000000000000000000000000000000003f4)
            )
        );
        require(success);
        vm.prank(USER);
        (success,) =
            address(this).call(abi.encodeCall(this.setPrice, (6663006047491614880599209616220218899614508160112)));
        require(success);
        vm.prank(USER);
        (success,) = address(this).call(abi.encodeCall(this.mine, (347004)));
        require(success);
        vm.prank(USER);
        (success,) = address(this).call(
            abi.encodeCall(
                this.liquidateSeizedAssetsNoRevert,
                (
                    1,
                    115792089237316195423570985008687907853269984665640564039457584007913129639934,
                    1405888047604400359344857338824181942093566199035292748
                )
            )
        );
        require(success);
    }
```
</details>