### PR TITLE
[Certora] Quick refactor

### DIFF
--- a/certora/confs/AccrueInterest.conf
+++ b/certora/confs/AccrueInterest.conf
@@ -1,15 +1,15 @@
 {
-    "files": [
-        "certora/harness/MorphoHarness.sol",
-    ],
-    "solc": "solc-0.8.19",
-    "verify": "MorphoHarness:certora/specs/AccrueInterest.spec",
-    "prover_args": [
-        "-depth 3",
-        "-mediumTimeout 30",
-        "-smt_hashingScheme plaininjectivity",
-    ],
-    "rule_sanity": "basic",
-    "server": "production",
-    "msg": "Morpho Blue Accrue Interest"
+  "files": [
+    "certora/harness/MorphoHarness.sol"
+  ],
+  "solc": "solc-0.8.19",
+  "verify": "MorphoHarness:certora/specs/AccrueInterest.spec",
+  "prover_args": [
+    "-depth 3",
+    "-mediumTimeout 30",
+    "-smt_hashingScheme plaininjectivity"
+  ],
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Morpho Blue Accrue Interest"
 }

--- a/certora/confs/AssetsAccounting.conf
+++ b/certora/confs/AssetsAccounting.conf
@@ -1,10 +1,10 @@
 {
-    "files": [
-        "certora/harness/MorphoHarness.sol",
-    ],
-    "solc": "solc-0.8.19",
-    "verify": "MorphoHarness:certora/specs/AssetsAccounting.spec",
-    "rule_sanity": "basic",
-    "server": "production",
-    "msg": "Morpho Blue Assets Accounting"
+  "files": [
+    "certora/harness/MorphoHarness.sol"
+  ],
+  "solc": "solc-0.8.19",
+  "verify": "MorphoHarness:certora/specs/AssetsAccounting.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Morpho Blue Assets Accounting"
 }

--- a/certora/confs/ConsistentState.conf
+++ b/certora/confs/ConsistentState.conf
@@ -1,10 +1,10 @@
 {
-    "files": [
-        "certora/harness/MorphoHarness.sol",
-    ],
-    "solc": "solc-0.8.19",
-    "verify": "MorphoHarness:certora/specs/ConsistentState.spec",
-    "rule_sanity": "basic",
-    "server": "production",
-    "msg": "Morpho Blue Consistent State"
+  "files": [
+    "certora/harness/MorphoHarness.sol"
+  ],
+  "solc": "solc-0.8.19",
+  "verify": "MorphoHarness:certora/specs/ConsistentState.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Morpho Blue Consistent State"
 }

--- a/certora/confs/ExactMath.conf
+++ b/certora/confs/ExactMath.conf
@@ -1,19 +1,18 @@
 {
-    "files": [
-        "certora/harness/MorphoHarness.sol",
-    ],
-    "solc": "solc-0.8.19",
-    "verify": "MorphoHarness:certora/specs/ExactMath.spec",
-    "rule_sanity": "basic",
-    "prover_args": [
-        "-depth 5",
-        "-mediumTimeout 5",
-        "-timeout 3600",
-        "-adaptiveSolverConfig false",
-        "-smt_nonLinearArithmetic true",
-        "-solvers [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:lia2]",
-    ],
-    "cache": "none",
-    "server": "production",
-    "msg": "Morpho Blue Exact Math"
+  "files": [
+    "certora/harness/MorphoHarness.sol"
+  ],
+  "solc": "solc-0.8.19",
+  "verify": "MorphoHarness:certora/specs/ExactMath.spec",
+  "rule_sanity": "basic",
+  "prover_args": [
+    "-depth 5",
+    "-mediumTimeout 5",
+    "-timeout 3600",
+    "-adaptiveSolverConfig false",
+    "-smt_nonLinearArithmetic true",
+    "-solvers [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:lia2]"
+  ],
+  "server": "production",
+  "msg": "Morpho Blue Exact Math"
 }

--- a/certora/confs/ExactMath.conf
+++ b/certora/confs/ExactMath.conf
@@ -4,7 +4,6 @@
   ],
   "solc": "solc-0.8.19",
   "verify": "MorphoHarness:certora/specs/ExactMath.spec",
-  "rule_sanity": "basic",
   "prover_args": [
     "-depth 5",
     "-mediumTimeout 5",
@@ -13,6 +12,7 @@
     "-smt_nonLinearArithmetic true",
     "-solvers [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:lia2]"
   ],
+  "rule_sanity": "basic",
   "server": "production",
   "msg": "Morpho Blue Exact Math"
 }

--- a/certora/confs/ExchangeRate.conf
+++ b/certora/confs/ExchangeRate.conf
@@ -1,14 +1,14 @@
 {
-    "files": [
-        "certora/harness/MorphoHarness.sol",
-    ],
-    "solc": "solc-0.8.19",
-    "verify": "MorphoHarness:certora/specs/ExchangeRate.spec",
-    "rule_sanity": "basic",
-    "prover_args": [
-        "-smt_hashingScheme plaininjectivity",
-        "-smt_easy_LIA true",
-    ],
-    "server": "production",
-    "msg": "Morpho Blue Exchange Rate"
+  "files": [
+    "certora/harness/MorphoHarness.sol"
+  ],
+  "solc": "solc-0.8.19",
+  "verify": "MorphoHarness:certora/specs/ExchangeRate.spec",
+  "rule_sanity": "basic",
+  "prover_args": [
+    "-smt_hashingScheme plaininjectivity",
+    "-smt_easy_LIA true"
+  ],
+  "server": "production",
+  "msg": "Morpho Blue Exchange Rate"
 }

--- a/certora/confs/ExchangeRate.conf
+++ b/certora/confs/ExchangeRate.conf
@@ -4,11 +4,11 @@
   ],
   "solc": "solc-0.8.19",
   "verify": "MorphoHarness:certora/specs/ExchangeRate.spec",
-  "rule_sanity": "basic",
   "prover_args": [
     "-smt_hashingScheme plaininjectivity",
     "-smt_easy_LIA true"
   ],
+  "rule_sanity": "basic",
   "server": "production",
   "msg": "Morpho Blue Exchange Rate"
 }

--- a/certora/confs/Health.conf
+++ b/certora/confs/Health.conf
@@ -1,14 +1,14 @@
 {
-    "files": [
-        "certora/harness/MorphoHarness.sol",
-        "src/mocks/OracleMock.sol"
-    ],
-    "solc": "solc-0.8.19",
-    "verify": "MorphoHarness:certora/specs/Health.spec",
-    "rule_sanity": "basic",
-    "prover_args": [
-        "-smt_hashingScheme plaininjectivity",
-    ],
-    "server": "production",
-    "msg": "Morpho Blue Health"
+  "files": [
+    "certora/harness/MorphoHarness.sol",
+    "src/mocks/OracleMock.sol"
+  ],
+  "solc": "solc-0.8.19",
+  "verify": "MorphoHarness:certora/specs/Health.spec",
+  "rule_sanity": "basic",
+  "prover_args": [
+    "-smt_hashingScheme plaininjectivity"
+  ],
+  "server": "production",
+  "msg": "Morpho Blue Health"
 }

--- a/certora/confs/Health.conf
+++ b/certora/confs/Health.conf
@@ -5,10 +5,10 @@
   ],
   "solc": "solc-0.8.19",
   "verify": "MorphoHarness:certora/specs/Health.spec",
-  "rule_sanity": "basic",
   "prover_args": [
     "-smt_hashingScheme plaininjectivity"
   ],
+  "rule_sanity": "basic",
   "server": "production",
   "msg": "Morpho Blue Health"
 }

--- a/certora/confs/LibSummary.conf
+++ b/certora/confs/LibSummary.conf
@@ -1,13 +1,13 @@
 {
-    "files": [
-        "certora/harness/MorphoHarness.sol",
-    ],
-    "solc": "solc-0.8.19",
-    "verify": "MorphoHarness:certora/specs/LibSummary.spec",
-    "rule_sanity": "basic",
-    "prover_args": [
-        "-smt_bitVectorTheory true"
-    ],
-    "server": "production",
-    "msg": "Morpho Blue Lib Summary"
+  "files": [
+    "certora/harness/MorphoHarness.sol"
+  ],
+  "solc": "solc-0.8.19",
+  "verify": "MorphoHarness:certora/specs/LibSummary.spec",
+  "rule_sanity": "basic",
+  "prover_args": [
+    "-smt_bitVectorTheory true"
+  ],
+  "server": "production",
+  "msg": "Morpho Blue Lib Summary"
 }

--- a/certora/confs/LibSummary.conf
+++ b/certora/confs/LibSummary.conf
@@ -4,10 +4,10 @@
   ],
   "solc": "solc-0.8.19",
   "verify": "MorphoHarness:certora/specs/LibSummary.spec",
-  "rule_sanity": "basic",
   "prover_args": [
     "-smt_bitVectorTheory true"
   ],
+  "rule_sanity": "basic",
   "server": "production",
   "msg": "Morpho Blue Lib Summary"
 }

--- a/certora/confs/Liveness.conf
+++ b/certora/confs/Liveness.conf
@@ -1,10 +1,10 @@
 {
-    "files": [
-        "certora/harness/MorphoInternalAccess.sol",
-    ],
-    "solc": "solc-0.8.19",
-    "verify": "MorphoInternalAccess:certora/specs/Liveness.spec",
-    "rule_sanity": "basic",
-    "server": "production",
-    "msg": "Morpho Blue Liveness"
+  "files": [
+    "certora/harness/MorphoInternalAccess.sol"
+  ],
+  "solc": "solc-0.8.19",
+  "verify": "MorphoInternalAccess:certora/specs/Liveness.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Morpho Blue Liveness"
 }

--- a/certora/confs/Reentrancy.conf
+++ b/certora/confs/Reentrancy.conf
@@ -1,13 +1,13 @@
 {
-    "files": [
-        "certora/harness/MorphoHarness.sol",
-    ],
-    "solc": "solc-0.8.19",
-    "verify": "MorphoHarness:certora/specs/Reentrancy.spec",
-    "rule_sanity": "basic",
-    "prover_args": [
-        "-enableStorageSplitting false",
-    ],
-    "server": "production",
-    "msg": "Morpho Blue Reentrancy"
+  "files": [
+    "certora/harness/MorphoHarness.sol"
+  ],
+  "solc": "solc-0.8.19",
+  "verify": "MorphoHarness:certora/specs/Reentrancy.spec",
+  "rule_sanity": "basic",
+  "prover_args": [
+    "-enableStorageSplitting false"
+  ],
+  "server": "production",
+  "msg": "Morpho Blue Reentrancy"
 }

--- a/certora/confs/Reentrancy.conf
+++ b/certora/confs/Reentrancy.conf
@@ -4,10 +4,10 @@
   ],
   "solc": "solc-0.8.19",
   "verify": "MorphoHarness:certora/specs/Reentrancy.spec",
-  "rule_sanity": "basic",
   "prover_args": [
     "-enableStorageSplitting false"
   ],
+  "rule_sanity": "basic",
   "server": "production",
   "msg": "Morpho Blue Reentrancy"
 }

--- a/certora/confs/Reverts.conf
+++ b/certora/confs/Reverts.conf
@@ -1,10 +1,10 @@
 {
-    "files": [
-        "certora/harness/MorphoHarness.sol",
-    ],
-    "solc": "solc-0.8.19",
-    "verify": "MorphoHarness:certora/specs/Reverts.spec",
-    "rule_sanity": "basic",
-    "server": "production",
-    "msg": "Morpho Blue Reverts"
+  "files": [
+    "certora/harness/MorphoHarness.sol"
+  ],
+  "solc": "solc-0.8.19",
+  "verify": "MorphoHarness:certora/specs/Reverts.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Morpho Blue Reverts"
 }

--- a/certora/confs/StayHealthy.conf
+++ b/certora/confs/StayHealthy.conf
@@ -3,16 +3,13 @@
     "certora/harness/MorphoHarness.sol",
     "src/mocks/OracleMock.sol"
   ],
-  "msg": "Morpho Blue Stay Healthy",
-  "process": "emv",
+  "solc": "solc-0.8.19",
+  "verify": "MorphoHarness:certora/specs/StayHealthy.spec",
   "prover_args": [
-    "-depth 5",
-    "-mediumTimeout 5",
-    "-timeout 3600",
-    "-smt_hashingScheme plaininjectivity"
+    "-smt_hashingScheme plaininjectivity",
+    "-solvers [yices,z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:def{randomSeed=8},z3:def{randomSeed=9},z3:def{randomSeed=10}]"
   ],
   "rule_sanity": "basic",
   "server": "production",
-  "solc": "solc-0.8.19",
-  "verify": "MorphoHarness:certora/specs/StayHealthy.spec"
+  "msg": "Morpho Blue Stay Healthy"
 }

--- a/certora/confs/StayHealthy.conf
+++ b/certora/confs/StayHealthy.conf
@@ -1,18 +1,18 @@
 {
-	"files": [
-		"certora/harness/MorphoHarness.sol",
-		"src/mocks/OracleMock.sol",
-	],
-	"msg": "Morpho Blue Stay Healthy",
-	"process": "emv",
-	"prover_args": [
-		"-depth 5",
-		"-mediumTimeout 5",
-		"-timeout 3600",
-		"-smt_hashingScheme plaininjectivity"
-	],
-	"rule_sanity": "basic",
-	"server": "production",
-	"solc": "solc-0.8.19",
-	"verify": "MorphoHarness:certora/specs/StayHealthy.spec"
+  "files": [
+    "certora/harness/MorphoHarness.sol",
+    "src/mocks/OracleMock.sol"
+  ],
+  "msg": "Morpho Blue Stay Healthy",
+  "process": "emv",
+  "prover_args": [
+    "-depth 5",
+    "-mediumTimeout 5",
+    "-timeout 3600",
+    "-smt_hashingScheme plaininjectivity"
+  ],
+  "rule_sanity": "basic",
+  "server": "production",
+  "solc": "solc-0.8.19",
+  "verify": "MorphoHarness:certora/specs/StayHealthy.spec"
 }

--- a/certora/confs/Transfer.conf
+++ b/certora/confs/Transfer.conf
@@ -1,13 +1,13 @@
 {
-    "files": [
-        "certora/harness/TransferHarness.sol",
-        "certora/dispatch/ERC20Standard.sol",
-        "certora/dispatch/ERC20USDT.sol",
-        "certora/dispatch/ERC20NoRevert.sol",
-    ],
-    "solc": "solc-0.8.19",
-    "verify": "TransferHarness:certora/specs/Transfer.spec",
-    "rule_sanity": "basic",
-    "server": "production",
-    "msg": "Morpho Blue Transfer"
+  "files": [
+    "certora/harness/TransferHarness.sol",
+    "certora/dispatch/ERC20Standard.sol",
+    "certora/dispatch/ERC20USDT.sol",
+    "certora/dispatch/ERC20NoRevert.sol"
+  ],
+  "solc": "solc-0.8.19",
+  "verify": "TransferHarness:certora/specs/Transfer.spec",
+  "rule_sanity": "basic",
+  "server": "production",
+  "msg": "Morpho Blue Transfer"
 }

--- a/certora/specs/Health.spec
+++ b/certora/specs/Health.spec
@@ -67,7 +67,6 @@ filtered { f -> !f.isView }
 
     mathint collateralBefore = collateral(id, user);
 
-    priceChanged = false;
     f(e, data);
 
     mathint collateralAfter = collateral(id, user);


### PR DESCRIPTION
This PR:
- removes the unnecessary `priceChanged = false` in the spec. This is not necessary because we assume that `priceChanged` is false at the end, and the only way it can change is by being set to true
- removes the setting `cache` to `none` in `ExactMath.conf`, which was there as an artifact of an old timeout
- formats the conf files according to Prettier rules for JSON files
- solves a timeout in StayHealthyLiquidate that was coming back at every new CVL release