### PR TITLE
Fix license warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@morpho-org/morpho-blue",
   "description": "Morpho Blue Protocol",
-  "license": "BUSL-1.1",
+  "license": "SEE LICENSE IN README.md",
   "version": "1.0.0",
   "files": [
     "src",


### PR DESCRIPTION
Looking into it it seems like the warning comes from:
- yarn using [validate-npm-package-license](https://github.com/kemitchell/validate-npm-package-license.js) at version ^3.0.4
- validate-npm-package-license using [spdx-expression-parse](https://github.com/jslicense/spdx-expression-parse.js) at version ^3.0.0
- spdx-expression-parse using [spdx-license-ids](https://github.com/jslicense/spdx-license-ids) at version ^3.0.0

However spdx-license-ids only added `BUSL-1.1` at version 3.0.7, see [here](https://github.com/jslicense/spdx-license-ids/compare/v3.0.6...v3.0.7). So it seems like it's not required for yarn to use the version that includes the `BUSL-1.1` identifier.

In any case, fixing it would require an update of yarn, but they seem to not accept any PR on version 1 now, unless it's fixing a critical vulnerability.

Instead I propose to bypass the check of yarn, as allowed [here](https://github.com/kemitchell/validate-npm-package-license.js/blob/0a53a16123c70931d0b6afc881616cfff1c0fe41/index.js#L11). And for morpho-blue it feels like it makes sense because there is a dual license BUSL + GPL