### PR TITLE
Fix stay healthy liquidate rule depending on cache

### DIFF
--- a/certora/confs/StayHealthy.conf
+++ b/certora/confs/StayHealthy.conf
@@ -9,7 +9,6 @@
   "prover_args": [
     "-solvers [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:def{randomSeed=8},z3:def{randomSeed=9},z3:def{randomSeed=10}]"
   ],
-  "cache": "none",
   "multi_assert_check": true,
   "rule_sanity": "basic",
   "server": "production",

--- a/certora/confs/StayHealthy.conf
+++ b/certora/confs/StayHealthy.conf
@@ -10,6 +10,7 @@
     "-solvers [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:def{randomSeed=8},z3:def{randomSeed=9},z3:def{randomSeed=10}]"
   ],
   "cache": "none",
+  "multi_assert_check": true,
   "rule_sanity": "basic",
   "server": "production",
   "msg": "Morpho Blue Stay Healthy"

--- a/certora/confs/StayHealthy.conf
+++ b/certora/confs/StayHealthy.conf
@@ -7,6 +7,7 @@
   "solc": "solc-0.8.19",
   "verify": "MorphoHarness:certora/specs/StayHealthy.spec",
   "prover_args": [
+    "-cache none",
     "-solvers [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:def{randomSeed=8},z3:def{randomSeed=9},z3:def{randomSeed=10}]"
   ],
   "rule_sanity": "basic",

--- a/certora/confs/StayHealthy.conf
+++ b/certora/confs/StayHealthy.conf
@@ -7,9 +7,9 @@
   "solc": "solc-0.8.19",
   "verify": "MorphoHarness:certora/specs/StayHealthy.spec",
   "prover_args": [
-    "-cache none",
     "-solvers [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:def{randomSeed=8},z3:def{randomSeed=9},z3:def{randomSeed=10}]"
   ],
+  "cache": "none",
   "rule_sanity": "basic",
   "server": "production",
   "msg": "Morpho Blue Stay Healthy"


### PR DESCRIPTION
This spec times out from time to time : see second commit CI run to see that. The fix is in third commit. 

The `"cache" : "none"` was added to show that it fixes the issue (otherwise it always goes through thanks to the cache)