### PR TITLE
Add verifier for OP funding

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -1,0 +1,5 @@
+{
+	"opRetro": {
+		"projectId": "0xda8c593717693ef30f5c62fc2689709784324cfb9b5fe92c9db3a47f596791e5"
+	}
+}


### PR DESCRIPTION
We need to do this to verify the repo for OP retroactive funding.

<img width="2518" alt="image" src="https://github.com/user-attachments/assets/cff753c5-25fb-4e39-8fba-3740929b13b5" />
<img width="2518" alt="image" src="https://github.com/user-attachments/assets/82730eed-6df9-4660-8d73-2aa6779477bf" />
