### PR TITLE
[Certora] Simplify summarization of mulDiv and price

### DIFF
--- a/certora/confs/StayHealthy.conf
+++ b/certora/confs/StayHealthy.conf
@@ -7,9 +7,6 @@
   "solc": "solc-0.8.19",
   "verify": "MorphoHarness:certora/specs/StayHealthy.spec",
   "prover_args": [
-    "-depth 5",
-    "-mediumTimeout 20",
-    "-timeout 3600",
     "-solvers [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:def{randomSeed=8},z3:def{randomSeed=9},z3:def{randomSeed=10}]"
   ],
   "multi_assert_check": true,

--- a/certora/confs/StayHealthy.conf
+++ b/certora/confs/StayHealthy.conf
@@ -7,6 +7,9 @@
   "solc": "solc-0.8.19",
   "verify": "MorphoHarness:certora/specs/StayHealthy.spec",
   "prover_args": [
+    "-depth 5",
+    "-mediumTimeout 20",
+    "-timeout 3600",
     "-solvers [z3:def{randomSeed=1},z3:def{randomSeed=2},z3:def{randomSeed=3},z3:def{randomSeed=4},z3:def{randomSeed=5},z3:def{randomSeed=6},z3:def{randomSeed=7},z3:def{randomSeed=8},z3:def{randomSeed=9},z3:def{randomSeed=10}]"
   ],
   "multi_assert_check": true,

--- a/certora/specs/ExactMath.spec
+++ b/certora/specs/ExactMath.spec
@@ -18,21 +18,9 @@ methods {
     function Util.maxFee() external returns uint256 envfree;
     function Util.libId(MorphoHarness.MarketParams) external returns MorphoHarness.Id envfree;
 
-    function MathLib.mulDivDown(uint256 a, uint256 b, uint256 c) internal returns uint256 => summaryMulDivDown(a,b,c);
-    function MathLib.mulDivUp(uint256 a, uint256 b, uint256 c) internal returns uint256 => summaryMulDivUp(a,b,c);
     function SafeTransferLib.safeTransfer(address token, address to, uint256 value) internal => NONDET;
     function SafeTransferLib.safeTransferFrom(address token, address from, address to, uint256 value) internal => NONDET;
     function _.onMorphoSupply(uint256 assets, bytes data) external => HAVOC_ECF;
-}
-
-function summaryMulDivUp(uint256 x, uint256 y, uint256 d) returns uint256 {
-    // Safe require because the reference implementation would revert.
-    return require_uint256((x * y + (d - 1)) / d);
-}
-
-function summaryMulDivDown(uint256 x, uint256 y, uint256 d) returns uint256 {
-    // Safe require because the reference implementation would revert.
-    return require_uint256((x * y) / d);
 }
 
 // Check that when not accruing interest, and when repaying all, the borrow exchange rate is at least reset to the initial exchange rate.

--- a/certora/specs/Health.spec
+++ b/certora/specs/Health.spec
@@ -18,7 +18,7 @@ methods {
     function Util.libId(MorphoHarness.MarketParams) external returns MorphoHarness.Id envfree;
     function isHealthy(MorphoHarness.MarketParams, address user) external returns bool envfree;
 
-    function _.price() external => CONSTANT expect uint256;
+    function _.price() external => CONSTANT;
     function UtilsLib.min(uint256 a, uint256 b) internal returns uint256 => summaryMin(a,b);
 }
 

--- a/certora/specs/Health.spec
+++ b/certora/specs/Health.spec
@@ -18,34 +18,8 @@ methods {
     function Util.libId(MorphoHarness.MarketParams) external returns MorphoHarness.Id envfree;
     function isHealthy(MorphoHarness.MarketParams, address user) external returns bool envfree;
 
-    function _.price() external => mockPrice() expect uint256;
-    function MathLib.mulDivDown(uint256 a, uint256 b, uint256 c) internal returns uint256 => summaryMulDivDown(a,b,c);
-    function MathLib.mulDivUp(uint256 a, uint256 b, uint256 c) internal returns uint256 => summaryMulDivUp(a,b,c);
+    function _.price() external => CONSTANT expect uint256;
     function UtilsLib.min(uint256 a, uint256 b) internal returns uint256 => summaryMin(a,b);
-}
-
-persistent ghost uint256 lastPrice;
-persistent ghost bool priceChanged;
-
-function mockPrice() returns uint256 {
-    uint256 updatedPrice;
-    if (updatedPrice != lastPrice) {
-        priceChanged = true;
-        lastPrice = updatedPrice;
-    }
-    return updatedPrice;
-}
-
-function summaryMulDivUp(uint256 x, uint256 y, uint256 d) returns uint256 {
-    // Safe require because the reference implementation would revert.
-    require d != 0;
-    return require_uint256((x * y + (d - 1)) / d);
-}
-
-function summaryMulDivDown(uint256 x, uint256 y, uint256 d) returns uint256 {
-    // Safe require because the reference implementation would revert.
-    require d != 0;
-    return require_uint256((x * y) / d);
 }
 
 function summaryMin(uint256 a, uint256 b) returns uint256 {
@@ -74,7 +48,7 @@ filtered { f -> !f.isView }
 
     mathint collateralAfter = collateral(id, user);
 
-    assert !priceChanged => collateralAfter >= collateralBefore;
+    assert collateralAfter >= collateralBefore;
 }
 
 // Check that users without collateral also have no debt.
@@ -94,7 +68,6 @@ rule liquidateEquivalentInputDebtAndInputCollateral(env e, MorphoHarness.MarketP
 
     uint256 repaidAssets1;
     _, repaidAssets1 = liquidate(e, marketParams, borrower, seizedAssets, 0, data);
-    require !priceChanged;
     // Omit the bad debt realization case.
     require collateral(id, borrower) != 0;
     uint256 sharesAfter = borrowShares(id, borrower);
@@ -102,7 +75,6 @@ rule liquidateEquivalentInputDebtAndInputCollateral(env e, MorphoHarness.MarketP
 
     uint256 repaidAssets2;
     _, repaidAssets2 = liquidate(e, marketParams, borrower, 0, repaidShares1, data) at init;
-    require !priceChanged;
 
     assert repaidAssets1 == repaidAssets2;
 }

--- a/certora/specs/Health.spec
+++ b/certora/specs/Health.spec
@@ -42,13 +42,11 @@ filtered { f -> !f.isView }
     // Assume that the user is healthy.
     require isHealthy(marketParams, user);
 
-    mathint collateralBefore = collateral(id, user);
+    uint256 collateralBefore = collateral(id, user);
 
     f(e, data);
 
-    mathint collateralAfter = collateral(id, user);
-
-    assert collateralAfter >= collateralBefore;
+    assert collateral(id, user) >= collateralBefore;
 }
 
 // Check that users without collateral also have no debt.

--- a/certora/specs/StayHealthy.spec
+++ b/certora/specs/StayHealthy.spec
@@ -28,6 +28,12 @@ filtered {
     assert isHealthy(marketParams, user);
 }
 
+// Unsafe requires here.
+function mulDivUp(uint256 x, uint256 y, uint256 d) returns uint256 {
+    require d != 0;
+    return require_uint256((x * y + (d - 1)) / d);
+}
+
 // The liquidate case for the stayHealthy rule, assuming no bad debt realization, otherwise it times out.
 // This particular rule makes the following assumptions:
 //   - the market of the liquidation is the market of the user, see the *DifferentMarkets rule,
@@ -40,7 +46,7 @@ rule stayHealthyLiquidate(env e, MorphoHarness.MarketParams marketParams, addres
     require isHealthy(marketParams, user);
 
     uint256 debtSharesBefore = borrowShares(id, user);
-    mathint debtAssetsBefore = (debtSharesBefore * virtualTotalBorrowAssets(id)) / virtualTotalBorrowShares(id);
+    mathint debtAssetsBefore = mulDivUp(debtSharesBefore, virtualTotalBorrowAssets(id), virtualTotalBorrowShares(id));
     // Safe require because of the invariants onlyEnabledLltv and lltvSmallerThanWad in ConsistentState.spec.
     require marketParams.lltv < 10^18;
     // Assumption to ensure that no interest is accumulated.
@@ -57,7 +63,7 @@ rule stayHealthyLiquidate(env e, MorphoHarness.MarketParams marketParams, addres
 
     assert user != borrower;
     assert debtSharesBefore == borrowShares(id, user);
-    assert debtAssetsBefore >= (debtSharesBefore * virtualTotalBorrowAssets(id)) / virtualTotalBorrowShares(id);
+    assert debtAssetsBefore >= mulDivUp(debtSharesBefore, virtualTotalBorrowAssets(id), virtualTotalBorrowShares(id));
 
     assert isHealthy(marketParams, user);
 }

--- a/certora/specs/StayHealthy.spec
+++ b/certora/specs/StayHealthy.spec
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 import "Health.spec";
 
+function mulDivUp(uint256 x, uint256 y, uint256 d) returns uint256 {
+    assert d != 0;
+    return assert_uint256((x * y + (d - 1)) / d);
+}
+
 // Check that without accruing interest, no interaction can put an healthy account into an unhealthy one.
 // The liquidate function times out in this rule, but has been checked separately.
 rule stayHealthy(env e, method f, calldataarg data)
@@ -26,11 +31,6 @@ filtered {
     require borrowShares(id, user) <= totalBorrowShares(id);
 
     assert isHealthy(marketParams, user);
-}
-
-function mulDivUp(uint256 x, uint256 y, uint256 d) returns uint256 {
-    assert d != 0;
-    return assert_uint256((x * y + (d - 1)) / d);
 }
 
 // The liquidate case for the stayHealthy rule, assuming no bad debt realization, otherwise it times out.


### PR DESCRIPTION
This PR:
- removes summarization of mulDiv that was not needed
- simplifies the summarization of the oracle, that was essentially always used as a constant
- removes the assumption about summaryMulDiv in specs