### PR TITLE
[Certora] Remove gambit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,7 @@ docs/
 /node_modules
 
 # Certora
-.certora**
-emv-*-certora*
+.certora_internal/
 
 # Hardhat
 /types

--- a/certora/README.md
+++ b/certora/README.md
@@ -277,12 +277,3 @@ For example, at the root of the repository:
 ```
 certoraRun certora/confs/ConsistentState.conf --rule borrowLessThanSupply
 ```
-
-The `certora-cli` package also includes a `certoraMutate` binary.
-The file [`gambit.conf`](gambit.conf) provides a default configuration of the mutations.
-You can test to mutate the code and check it against a particular specification.
-For example, at the root of the repository:
-
-```
-certoraMutate --prover_conf certora/confs/ConsistentState.conf --mutation_conf certora/gambit.conf
-```

--- a/certora/gambit.conf
+++ b/certora/gambit.conf
@@ -1,6 +1,0 @@
- {
-      "filename" : "../src/Morpho.sol",
-      "sourceroot": "..",
-      "num_mutants": 15,
-      "solc_remappings": []
-}


### PR DESCRIPTION
Remove Gambit because:
- it has changed, and can't be used that way anymore
- it's not useful in production, we already ran it
- it doesn't fit out use case that well, because it runs a given specification for many mutants. This is not so useful, because the fact that a mutant is not killed by a given specification is not informative: it could be killed by another specification. For a given mutant, we would like to run the verification on each specification