### PR TITLE
Add specs and confs for foundry tests under `test/forge/libraries`

### DIFF
--- a/certora/foundry/confs/libraries/MathLibTest.conf
+++ b/certora/foundry/confs/libraries/MathLibTest.conf
@@ -1,0 +1,12 @@
+{
+    build_cache: true,
+    files: [
+        "test/forge/libraries/MathLibTest.sol"
+    ],
+    foundry_tests_mode: true,
+    packages: [
+        "ds-test=lib/forge-std/lib/ds-test/src"
+    ],
+    solc: "solc8.19",
+    verify: "MathLibTest:certora/foundry/specs/Test.spec",
+}

--- a/certora/foundry/confs/libraries/SafeTransferLibTest.conf
+++ b/certora/foundry/confs/libraries/SafeTransferLibTest.conf
@@ -1,0 +1,19 @@
+{
+    auto_dispatcher: true,
+    build_cache: true,
+    files: [
+        "test/forge/libraries/SafeTransferLibTest.sol",
+        "test/forge/libraries/SafeTransferLibTest.sol:ERC20WithoutBoolean",
+        "test/forge/libraries/SafeTransferLibTest.sol:ERC20WithBooleanAlwaysFalse",
+    ],
+    foundry_tests_mode: true,
+    link: [
+        "SafeTransferLibTest:tokenWithoutBoolean=ERC20WithoutBoolean",
+        "SafeTransferLibTest:tokenWithBooleanAlwaysFalse=ERC20WithBooleanAlwaysFalse",
+    ],
+    packages: [
+        "ds-test=lib/forge-std/lib/ds-test/src"
+    ],
+    solc: "solc8.19",
+    verify: "SafeTransferLibTest:certora/foundry/specs/Test.spec",
+}

--- a/certora/foundry/confs/libraries/UtilsLibTest.conf
+++ b/certora/foundry/confs/libraries/UtilsLibTest.conf
@@ -1,0 +1,12 @@
+{
+    build_cache: true,
+    files: [
+        "test/forge/libraries/UtilsLibTest.sol"
+    ],
+    foundry_tests_mode: true,
+    packages: [
+        "ds-test=lib/forge-std/lib/ds-test/src"
+    ],
+    solc: "solc8.19",
+    verify: "UtilsLibTest:certora/foundry/specs/Test.spec",
+}

--- a/certora/foundry/confs/libraries/periphery/MorphoBalancesLibTest.conf
+++ b/certora/foundry/confs/libraries/periphery/MorphoBalancesLibTest.conf
@@ -1,0 +1,21 @@
+{
+    auto_dispatcher: true,
+    build_cache: true,
+    dynamic_bound: "2",
+    dynamic_dispatch: true,
+    files: [
+        "test/forge/libraries/periphery/MorphoBalancesLibTest.sol",
+        "src/Morpho.sol",
+        "src/mocks/ERC20Mock.sol",
+        "src/mocks/OracleMock.sol",
+        "src/mocks/IrmMock.sol",
+    ],
+    foundry_tests_mode: true,
+    loop_iter: "2",
+    optimistic_loop: true,
+    packages: [
+        "ds-test=lib/forge-std/lib/ds-test/src"
+    ],
+    solc: "solc8.19",
+    verify: "MorphoBalancesLibTest:certora/foundry/specs/BaseTest.spec",
+}

--- a/certora/foundry/confs/libraries/periphery/MorphoLibTest.conf
+++ b/certora/foundry/confs/libraries/periphery/MorphoLibTest.conf
@@ -1,0 +1,21 @@
+{
+    auto_dispatcher: true,
+    build_cache: true,
+    dynamic_bound: "2",
+    dynamic_dispatch: true,
+    files: [
+        "test/forge/libraries/periphery/MorphoLibTest.sol",
+        "src/Morpho.sol",
+        "src/mocks/ERC20Mock.sol",
+        "src/mocks/OracleMock.sol",
+        "src/mocks/IrmMock.sol",
+    ],
+    foundry_tests_mode: true,
+    loop_iter: "2",
+    optimistic_loop: true,
+    packages: [
+        "ds-test=lib/forge-std/lib/ds-test/src"
+    ],
+    solc: "solc8.19",
+    verify: "MorphoLibTest:certora/foundry/specs/BaseTest.spec",
+}

--- a/certora/foundry/confs/libraries/periphery/MorphoStorageLibTest.conf
+++ b/certora/foundry/confs/libraries/periphery/MorphoStorageLibTest.conf
@@ -1,0 +1,21 @@
+{
+    auto_dispatcher: true,
+    build_cache: true,
+    dynamic_bound: "2",
+    dynamic_dispatch: true,
+    files: [
+        "test/forge/libraries/periphery/MorphoStorageLibTest.sol",
+        "src/Morpho.sol",
+        "src/mocks/ERC20Mock.sol",
+        "src/mocks/OracleMock.sol",
+        "src/mocks/IrmMock.sol",
+    ],
+    foundry_tests_mode: true,
+    loop_iter: "2",
+    optimistic_loop: true,
+    packages: [
+        "ds-test=lib/forge-std/lib/ds-test/src"
+    ],
+    solc: "solc8.19",
+    verify: "MorphoStorageLibTest:certora/foundry/specs/BaseTest.spec",
+}

--- a/certora/foundry/runFoundry.sh
+++ b/certora/foundry/runFoundry.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Script to find and run certoraRun on all .conf files
+
+# Get the directory where the script is located
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+# Set error handling
+set -e
+
+echo "Searching for .conf files..."
+
+# Find all .conf files in the certora/foundry directory and subdirectories
+conf_files=$(find "$SCRIPT_DIR" -type f -name "*.conf")
+
+# Check if any conf files were found
+if [ -z "$conf_files" ]; then
+    echo "Error: No .conf files found in the certora/foundry directory or subdirectories."
+    exit 1
+fi
+
+# Count files found
+file_count=$(echo "$conf_files" | wc -l)
+echo "Found $file_count .conf files"
+
+# Counter for successful runs
+success_count=0
+failed_files=()
+
+# Loop through each .conf file
+for conf_file in $conf_files; do
+    echo "Running certoraRun on $conf_file..."
+    if certoraRun "$conf_file" --server production --prover_version master; then
+        echo "Successfully processed $conf_file"
+        ((success_count++))
+    else
+        echo "Error: Failed to process $conf_file"
+        failed_files+=("$conf_file")
+    fi
+done
+
+# Print summary
+echo "------------------------"
+echo "Summary:"
+echo "Total files: $file_count"
+echo "Successful: $success_count"
+echo "Failed: ${#failed_files[@]}"
+
+# Print failed files if any
+if [ ${#failed_files[@]} -gt 0 ]; then
+    echo "Failed files:"
+    for file in "${failed_files[@]}"; do
+        echo "  - $file"
+    done
+    exit 1
+fi
+
+echo "All .conf files processed successfully."
+exit 0
+

--- a/certora/foundry/specs/BaseTest.spec
+++ b/certora/foundry/specs/BaseTest.spec
@@ -1,0 +1,5 @@
+use builtin rule verifyFoundryFuzzTests;
+
+override function init_fuzz_tests(method f, env e) {
+    setUp(e);
+}

--- a/certora/foundry/specs/Test.spec
+++ b/certora/foundry/specs/Test.spec
@@ -1,0 +1,1 @@
+use builtin rule verifyFoundryFuzzTests;

--- a/test/forge/libraries/SafeTransferLibTest.sol
+++ b/test/forge/libraries/SafeTransferLibTest.sol
@@ -61,12 +61,18 @@ contract SafeTransferLibTest is Test {
 
     function testSafeTransfer(address to, uint256 amount) public {
         tokenWithoutBoolean.setBalance(address(this), amount);
+        if(to != address(this) && tokenWithoutBoolean.balanceOf(to) > type(uint256).max - amount) {
+            vm.expectRevert();
+        }
 
         this.safeTransfer(address(tokenWithoutBoolean), to, amount);
     }
 
     function testSafeTransferFrom(address from, address to, uint256 amount) public {
         tokenWithoutBoolean.setBalance(from, amount);
+        if(to != from && tokenWithoutBoolean.balanceOf(to) > type(uint256).max - amount) {
+            vm.expectRevert();
+        }
 
         this.safeTransferFrom(address(tokenWithoutBoolean), from, to, amount);
     }


### PR DESCRIPTION
Additionally add a script that triggers all of them.
Note - for a few tests in `SafeTransferLibTest` the fact that we start from an arbitrary state necessitated modifying those test functions a little to make them more robust (and actually improve their coverage).