### PR TITLE
Halmos Tests with Symbolic IRM

### DIFF
--- a/test/halmos/HalmosTest.sol
+++ b/test/halmos/HalmosTest.sol
@@ -19,8 +19,6 @@ import {MathLib} from "../../src/libraries/MathLib.sol";
 
 // A symbolic IRM for Halmos Tests.
 contract IrmSymbolic is IIrm, SymTest, Test {
-    using MathLib for uint128;
-
     function borrowRateView(MarketParams memory, Market memory) public pure returns (uint256) {
         // Returns a symbolic borrow rate.
         return 50;


### PR DESCRIPTION
Added a symbolic IRM contract which returns a non-deterministic rate for the borrowRate() and borrowRateView() functions. The Morpho contract now calls a symbolic IRM instead of Mock IRM. Halmos tests pass with slightly higher path exploration. 