### PR TITLE
Halmos Soundness sanity check

### DIFF
--- a/test/halmos/HalmosTest.sol
+++ b/test/halmos/HalmosTest.sol
@@ -200,14 +200,26 @@ contract HalmosTest is SymTest, Test {
         assert(Id.unwrap(itmpBefore.id()) == Id.unwrap(itmpAfter.id()));
     }
 
-    function check_isInterestRateZeroWithIRMMock(bytes4 selector, address caller, Id id) public {
+    function check_isTotalBorrowAssetsZeroForFixedMarketID(bytes4 selector, address caller) public {
+        Id id = marketParams.id();
         uint256 totalBorrowAssetsBefore = morpho.totalBorrowAssets(id);
-        uint64 blockNumber = uint64(block.number);
-        vm.roll(blockNumber + 100);
-        _callMorpho(selector, caller);
 
+        _callMorpho(selector, caller);
+        
         uint256 totalBorrowAssetsAfter = morpho.totalBorrowAssets(id);
-        assert(totalBorrowAssetsBefore == totalBorrowAssetsAfter);
+        assert(totalBorrowAssetsBefore == 0);
+        assert(totalBorrowAssetsAfter == 0);
     }
+
+    function check_isTotalBorrowAssetsZero(bytes4 selector, address caller, Id id) public {
+        uint256 totalBorrowAssetsBefore = morpho.totalBorrowAssets(id);
+
+        _callMorpho(selector, caller);
+        
+        uint256 totalBorrowAssetsAfter = morpho.totalBorrowAssets(id);
+        assert(totalBorrowAssetsBefore == 0);
+        assert(totalBorrowAssetsAfter == 0);
+    }
+
 
 }


### PR DESCRIPTION
Minimal Example sanity checking soundness of Halmos tests.
check_isTotalBorrowAssetsZeroForFixedMarketID passes where as check_isTotalBorrowAssetsZero. Only difference is that former is calling on the fixed market (in setup) while marketId is passed as symbolic calldata in latter.

Halmos Output:

Counterexample: 
    halmos_assets_uint256_7b6d6b8_05 = 0x8000000000017fc00000000000000000
    halmos_block.timestamp_uint64_bee682a_04 = 0x01
    halmos_lltv_uint256_c41efa5_02 = 0x800000000000000
    halmos_onBehalf_address_f8832d3_07 = 0x00
    halmos_owner_address_f22c7fb_01 = 0x8000000000000000000000000000000000000000
    halmos_receiver_address_8a81ed8_08 = 0x8000000000000000000000000000000000000000
    p_caller_address_723f300_00 = 0x8000000000000000000000000000000000000000
    p_id_bytes32_904ef47_00 = 0x00
    p_selector_bytes4_767ebd9_00 = 0x8720316d00000000000000000000000000000000000000000000000000000000
[FAIL] check_isTotalBorrowAssetsZero(bytes4,address,bytes32) (paths: 136, time: 32.09s, bounds: [])
[PASS] check_isTotalBorrowAssetsZeroForFixedMarketID(bytes4,address) (paths: 60, time: 5.91s, bounds: [])
Looks like the selector in counterexample picks the borrow() function guessing from the args generated.

In the setup() we use [enableSymbolicStorage(address(morpho))](https://github.com/morpho-org/morpho-blue/blob/b813dced8e19ca780c537972ced8144308f35a87/test/halmos/HalmosTest.sol#L66), and totalBorrowAssets is part of the market mapping in storage.

TLDR;
TotalBorrowShares is set to zero and remains zero in FixedMarket, which is not the case if marketId is symbolic. Not sure if i am missing something that explains this behaviour from halmos.