### PR TITLE
Fix stray apostrophe in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Compilation, testing and formatting with [forge](https://book.getfoundry.sh/gett
 
 ## Audits
 
-All audits are stored in the [audits](./audits/)' folder.
+All audits are stored in the [audits](./audits/) folder.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Removes an erroneous apostrophe after the word "audits" in the Audits section of README.md
- The text incorrectly read `[audits](./audits/)' folder` instead of `[audits](./audits/) folder`

## Test plan
- [x] Visual inspection confirms the typo is removed