### PR TITLE
Fix grammar in ErrorsLib.sol INCONSISTENT_INPUT comment

### DIFF
--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -33,7 +33,7 @@ library ErrorsLib {
     /// @notice Thrown when the market is not created.
     string internal constant MARKET_NOT_CREATED = "market not created";
 
-    /// @notice Thrown when not exactly one of the input amount is zero.
+    /// @notice Thrown when not exactly one of the input amounts is zero.
     string internal constant INCONSISTENT_INPUT = "inconsistent input";
 
     /// @notice Thrown when zero assets is passed as input.


### PR DESCRIPTION
## Summary
- Fixes grammar error in the `INCONSISTENT_INPUT` error documentation
- Changed "input amount" to "input amounts" (plural)
- The comment refers to two input amounts (assets and shares), so the plural form is correct

## Test plan
- [x] Visual inspection confirms the grammar correction